### PR TITLE
Fix bug in 1s and 0s mask bit example

### DIFF
--- a/platforms/373/docs/README.tex
+++ b/platforms/373/docs/README.tex
@@ -152,7 +152,7 @@ Say for example the simulator fetches the instruction {\tt 0xb083}. (This is
 masks to see if it knows how to execute this instruction. A pair of opcode
 masks are made up of the ``{\tt ones\_mask}'' and ``{\tt zeros\_mask}''. These
 masks represent the bits that {\em must} be one and {\em must} be zero
-respectively. For example the masks {\tt (0xb0c2,0x4f40)} would match {\tt
+respectively. For example the masks {\tt (0xb002,0x4f40)} would match {\tt
 0xb083} while {\tt (0xb080,0x4f80)} would not. It is worth noting that some
 instructions may require multiple masks.
 


### PR DESCRIPTION
0x8 would not pass a 1s mask looking for 0xc.

Or at least I think I have this right.