### PR TITLE
Migrate to python3, and fix warnings/errors picked up by GCC 10.2

### DIFF
--- a/buses/bus.py
+++ b/buses/bus.py
@@ -22,7 +22,7 @@ class Bus(object):
             self.conn = conn
 
     def __init__(self):
-        raise NotImplementedError, "Abstract Base Class"
+        raise NotImplementedError("Abstract Base Class")
 
     def join(self):
         '''
@@ -31,7 +31,7 @@ class Bus(object):
         The join() function will join one of the Bus object's main threads, not
         returning unless the Bus object is destroyed.
         '''
-        raise NotImplementedError, "Abstract Base Class"
+        raise NotImplementedError("Abstract Base Class")
 
     def create(self, port):
         self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -136,8 +136,8 @@ I2C BUS {i}
                 elif c in ('x', 'X', ' '):
                     continue
                 else:
-                    raise self.I2CBusError,\
-                        "Illegal character in address mask: >>>" + c + "<<<"
+                    raise self.I2CBusError(
+                        "Illegal character in address mask: >>>" + c + "<<<")
 
     def join(self, timeout=None):
         self.accept_thread.join(timeout)
@@ -175,7 +175,7 @@ I2C BUS {i}
             acked = bool(self.recv_all(conn, 1))
             return (t, acked)
         else:
-            raise TypeError, "Unknown packet type: " + str(t) + " " + str(ord(t))
+            raise TypeError("Unknown packet type: " + str(t) + " " + str(ord(t)))
 
     def send_packet(self, conn, p):
         if p[0] == 0:
@@ -183,14 +183,14 @@ I2C BUS {i}
         elif p[0] == 1:
             msg = struct.pack("!BB", *p)
         else:
-            raise TypeError, "Unknown packet type: " + str(t) + " " + str(ord(t))
+            raise TypeError("Unknown packet type: " + str(t) + " " + str(ord(t)))
         conn.send(msg)
 
     def handle_message(self, conn):
         p = self.recv_packet(conn)
         if p[0] != 0:
             logging.debug("Got packet: " + str(p))
-            raise RuntimeError, "Unexpected ACK-type packet?"
+            raise RuntimeError("Unexpected ACK-type packet?")
         logging.debug("Got packet: MSG 0x%x %d: %s" % (p[1], p[2],
             " ".join(p[3].encode('hex')[i:i+2] for i in range(0,
                 len(p[3].encode('hex')), 2))))
@@ -222,7 +222,7 @@ I2C BUS {i}
                                 str(p))
                         continue
                     else:
-                        raise TypeError, "Unknown packet type: " + str(t)
+                        raise TypeError("Unknown packet type: " + str(t))
                 acked |= p[1]
 
             logging.debug("Got all ACK/NAKs, sending " + str(acked))
@@ -271,7 +271,7 @@ if args.BUS == "I2C":
     bus = I2CBus(int(args.PORT), args.address)
 else:
     logging.error("Unknown BUS type: " + args.BUS)
-    print parser.description
+    print(parser.description)
     sys.exit(1)
 
 while True:

--- a/platforms/HT_m3/programming/ein.py
+++ b/platforms/HT_m3/programming/ein.py
@@ -2,7 +2,7 @@
 
 import sys, socket
 import time
-import Queue
+import queue
 import logging
 
 from m3_common import m3_common
@@ -39,7 +39,7 @@ logger.info("Would you like to run after programming? If you do not")
 logger.info("have EIN Debug start the program, you will be prompted")
 logger.info("to send the start message via MBus at the end instead")
 logger.info("")
-resp = raw_input("Run program when programming finishes? [Y/n] ")
+resp = input("Run program when programming finishes? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     run_after = 0
 else:

--- a/platforms/HT_m3/programming/fake_ice.py
+++ b/platforms/HT_m3/programming/fake_ice.py
@@ -101,7 +101,7 @@ except:
     raise
 if not s.isOpen():
     logger.error('Could not open serial port at: ' + serial_port)
-    raise IOError, "Failed to open serial port"
+    raise IOError("Failed to open serial port")
 
 class Gpio(object):
     GPIO_INPUT    = 0
@@ -122,7 +122,7 @@ class Gpio(object):
         elif self.direction == Gpio.GPIO_TRISTATE:
             s += 'TRI'
         else:
-            raise RuntimeError, "wtf"
+            raise RuntimeError("wtf")
 
         s += ' - '
 
@@ -142,17 +142,17 @@ class Gpio(object):
     def __setattr__(self, name, value):
         if name is 'direction':
             if value not in (Gpio.GPIO_INPUT, Gpio.GPIO_OUTPUT, Gpio.GPIO_TRISTATE):
-                raise ValueError, "Attempt to set illegal direction", value
+                raise ValueError("Attempt to set illegal direction {}".format(value))
         if name is 'level':
             if value not in (True, False):
-                raise ValueError, "GPIO level must be true or false. Got", value
+                raise ValueError("GPIO level must be true or false. Got {}".format(value))
         if name is 'interrupt':
             if value not in (True, False):
-                raise ValueError, "GPIO interrupt must be true or false. Got", value
+                raise ValueError("GPIO interrupt must be true or false. Got {}".format(value))
         object.__setattr__(self, name, value)
 
 event = 0
-gpios = [Gpio() for x in xrange(MAX_GPIO)]
+gpios = [Gpio() for x in range(MAX_GPIO)]
 
 def respond(msg, ack=True):
     global s
@@ -331,19 +331,19 @@ while True:
             else:
                 if msg[0] == 'l':
                     mask = 0
-                    for i in xrange(len(gpios)):
+                    for i in range(len(gpios)):
                         mask |= (gpios[i].level << i)
                     logger.info("Responded to request for GPIO level mask (%06x)", mask)
                     respond(chr((mask >> 16) & 0xff) + chr((mask >> 8) & 0xff) + chr(mask >> 8))
                 elif msg[0] == 'd':
                     mask = 0
-                    for i in xrange(len(gpios)):
+                    for i in range(len(gpios)):
                         mask |= (gpios[i].direction << i)
                     logger.info("Responded to request for GPIO direction mask (%06x)", mask)
                     respond(chr((mask >> 16) & 0xff) + chr((mask >> 8) & 0xff) + chr(mask >> 8))
                 elif msg[0] == 'i':
                     mask = 0
-                    for i in xrange(len(gpios)):
+                    for i in range(len(gpios)):
                         mask |= (gpios[i].interrupt << i)
                     logger.info("Responded to request for GPIO interrupt mask (%06x)", mask)
                     respond(chr((mask >> 16) & 0xff) + chr((mask >> 8) & 0xff) + chr(mask >> 8))
@@ -366,23 +366,23 @@ while True:
                     raise Exception
             else:
                 if msg[0] == 'l':
-                    high,mid,low = map(ord, msg[1:])
+                    high,mid,low = list(map(ord, msg[1:]))
                     mask = low | mid << 8 | high << 16
-                    for i in xrange(24):
+                    for i in range(24):
                         gpios[i].level = (mask >> i) & 0x1
                     logger.info("Set GPIO level mask to: %06x", mask)
                     ack()
                 elif msg[0] == 'd':
-                    high,mid,low = map(ord, msg[1:])
+                    high,mid,low = list(map(ord, msg[1:]))
                     mask = low | mid << 8 | high << 16
-                    for i in xrange(24):
+                    for i in range(24):
                         gpios[i].direction = (mask >> i) & 0x1
                     logger.info("Set GPIO direction mask to: %06x", mask)
                     ack()
                 elif msg[0] == 'i':
-                    high,mid,low = map(ord, msg[1:])
+                    high,mid,low = list(map(ord, msg[1:]))
                     mask = low | mid << 8 | high << 16
-                    for i in xrange(24):
+                    for i in range(24):
                         gpios[i].interrupt = (mask >> i) & 0x1
                     logger.info("Set GPIO interrupt mask to: %06x", mask)
                     ack()
@@ -457,7 +457,7 @@ while True:
                         ("off", "on")[mbus_ismaster])
                 respond(chr(mbus_ismaster))
             elif msg[0] == 'c':
-                raise NotImplementedError, "MBus clock not defined"
+                raise NotImplementedError("MBus clock not defined")
             elif msg[0] == 'i':
                 logger.info("Responded to query for MBus should interrupt (%d)",
                         mbus_should_interrupt)
@@ -519,7 +519,7 @@ while True:
                 logger.info("MBus master mode set " + ("off", "on")[mbus_ismaster])
                 ack()
             elif msg[0] == 'c':
-                raise NotImplementedError, "MBus clock not defined"
+                raise NotImplementedError("MBus clock not defined")
             elif msg[0] == 'i':
                 mbus_should_interrupt = ord(msg[1])
                 logger.info("MBus should interrupt set to %d", mbus_should_interrupt)

--- a/platforms/HT_m3/programming/goc.py
+++ b/platforms/HT_m3/programming/goc.py
@@ -52,7 +52,7 @@ logger.info("Would you like to run after programming? If you do not")
 logger.info("have GOC start the program, you will be prompted to send")
 logger.info("the start message via DMA at the end instead")
 logger.info("")
-resp = raw_input("Run program when GOC finishes? [Y/n] ")
+resp = input("Run program when GOC finishes? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     run_after = 0
 else:

--- a/platforms/HT_m3/programming/gui.py
+++ b/platforms/HT_m3/programming/gui.py
@@ -8,12 +8,12 @@ import logging
 import inspect
 from datetime import datetime
 import glob
-import ConfigParser
-import Queue
+import configparser
+import queue
 import argparse
-import Tkinter as Tk
-import ttk
-import tkFileDialog, tkMessageBox
+import tkinter as Tk
+import tkinter.ttk
+import tkinter.filedialog, tkinter.messagebox
 from idlelib.WidgetRedirector import WidgetRedirector
 
 import m3_logging
@@ -74,12 +74,12 @@ def report_event(event):
 			"2": "KeyPress",
 			"4": "ButtonPress",
 			}
-	print("EventTime={}".format(event.time),
+	print(("EventTime={}".format(event.time),
 			"EventType={}".format(event.type),
 			event_name[str(event.type)],
 			"EventWidgetId={}".format(event.widget),
 			"EventKeySymbol={}".format(event.keysym)
-			)
+			))
 
 def add_returns(widget, callback):
 	widget.bind("<Return>", event_lambda(callback))
@@ -124,11 +124,11 @@ def make_modal(window, parent):
 	window.grab_set()
 	parent.wait_window(window)
 
-class ButtonWithReturns(ttk.Button):
+class ButtonWithReturns(tkinter.ttk.Button):
 	# n.b.: ttk.Button is an old-style class
 	def __init__(self, *args, **kwargs):
 		#logger.trace('ButtonWithReturns self {}'.format(repr(self)))
-		ttk.Button.__init__(self, *args, **kwargs)
+		tkinter.ttk.Button.__init__(self, *args, **kwargs)
 		try:
 			add_returns(self, kwargs['command'])
 		except KeyError:
@@ -156,7 +156,7 @@ def async_call(parent, fn, timeout_in_ms=500, cancellable=False):
 			ret = fn()
 			comp_queue.put(True)
 			comp_queue.put(ret)
-		except Exception, e:
+		except Exception as e:
 			comp_queue.put(False)
 			comp_queue.put(e)
 		comp_event.set()
@@ -174,7 +174,7 @@ def async_call(parent, fn, timeout_in_ms=500, cancellable=False):
 	comp_var = Tk.IntVar()
 	comp_var.set(0)
 	comp_event = threading.Event()
-	comp_queue = Queue.Queue()
+	comp_queue = queue.Queue()
 
 	t = threading.Thread(target=async_fn_wrapper,
 			args=(fn, comp_event, comp_queue))
@@ -188,10 +188,10 @@ def async_call(parent, fn, timeout_in_ms=500, cancellable=False):
 	if comp_var.get() == -1:
 		win = ModalWindow(parent)
 		win.title = "Long Running Task..."
-		ttk.Label(win, text="A requested command is taking too long to run",
+		tkinter.ttk.Label(win, text="A requested command is taking too long to run",
 				).pack()
-		ttk.Label(win, text="The long-running command is:").pack()
-		ttk.Label(win, text=str(m3_logging.fn_to_source(fn))).pack()
+		tkinter.ttk.Label(win, text="The long-running command is:").pack()
+		tkinter.ttk.Label(win, text=str(m3_logging.fn_to_source(fn))).pack()
 
 		if cancellable:
 			def cancel_async_call(win):
@@ -287,7 +287,7 @@ class Configuration(M3Gui):
 
 		self.status_label_text = Tk.StringVar(self.top)
 		self.status_label_text.set("< Uninitialized Text >")
-		self.status_label = ttk.Label(self.top, textvariable=self.status_label_text)
+		self.status_label = tkinter.ttk.Label(self.top, textvariable=self.status_label_text)
 		self.status_label.pack()
 
 		self.config_dir = os.path.join(os.getcwd(), 'configs')
@@ -378,7 +378,7 @@ class Configuration(M3Gui):
 			self.use_selected()
 
 	def change_directory(self):
-		new_dir = tkFileDialog.askdirectory(
+		new_dir = tkinter.filedialog.askdirectory(
 				initialdir=self.config_dir,
 				mustexist=True,
 				parent=self.top,
@@ -392,7 +392,7 @@ class Configuration(M3Gui):
 			return
 		else:
 			logger.error('Illegar dir: ' + str(new_dir))
-			tkMessageBox.showerror("Illegal Directory", "Please select a "\
+			tkinter.messagebox.showerror("Illegal Directory", "Please select a "\
 			"directory that actually exists. (As an aside: How did you "\
 			"manage to select one that doesn't exist?)")
 			return self.change_directory()
@@ -401,33 +401,33 @@ class Configuration(M3Gui):
 		def create_new_user():
 			uniq = entry.get()
 			if uniq in self.users:
-				tkMessageBox.showerror("Duplicate User",
+				tkinter.messagebox.showerror("Duplicate User",
 						"A user with that uniqname already exists.")
 			elif len(uniq):
 				new.destroy()
 				self.uniqname_var.set(uniq)
 				self.config_file = os.path.join(self.config_dir, uniq + '.ini')
-				self.config = ConfigParser.SafeConfigParser()
+				self.config = configparser.SafeConfigParser()
 				self.edit_configuration(cancellable=True)
 			else:
-				tkMessageBox.showerror("Blank uniqname",
+				tkinter.messagebox.showerror("Blank uniqname",
 						"Please enter a uniqname.")
 
 		new = ModalWindow(self.top, cancellable=True)
 		new.title('Create New User')
 
-		row0 = ttk.Frame(new)
+		row0 = tkinter.ttk.Frame(new)
 		row0.pack()
 
-		label = ttk.Label(row0, text="uniqname")
+		label = tkinter.ttk.Label(row0, text="uniqname")
 		label.pack(side=Tk.LEFT)
 
-		entry = ttk.Entry(row0)
+		entry = tkinter.ttk.Entry(row0)
 		entry.pack(fill=Tk.X)
 		add_returns(entry, create_new_user)
 		entry.focus_set()
 
-		row1 = ttk.Frame(new)
+		row1 = tkinter.ttk.Frame(new)
 		row1.pack(fill=Tk.X)
 
 		create = ButtonWithReturns(row1, text="Create", command=create_new_user)
@@ -447,7 +447,7 @@ class Configuration(M3Gui):
 
 	def parse_config(self, force_edit=False):
 		logger.debug('parse_config(force_eidt={})'.format(force_edit))
-		self.config = ConfigParser.SafeConfigParser()
+		self.config = configparser.SafeConfigParser()
 		self.config.read(self.config_file)
 		if force_edit:
 			self.edit_configuration(cancellable=False)
@@ -456,7 +456,7 @@ class Configuration(M3Gui):
 				self.last_updated = self.config.getint('DEFAULT', 'last-updated')
 				cur_time = int(time.time())
 				if cur_time - self.last_updated > M3Gui.ONE_DAY:
-					tkMessageBox.showinfo("Stale config file",
+					tkinter.messagebox.showinfo("Stale config file",
 							"Configuration file has not been"\
 							" updated in over 24 hours. Please verify that"\
 							" all information is still correct.")
@@ -464,8 +464,8 @@ class Configuration(M3Gui):
 				self.ws_var.set(self.config.get('DEFAULT', 'workstation'))
 				self.cs_var.set(self.config.get('DEFAULT', 'chips'))
 				self.notes_var.set(self.config.get('DEFAULT', 'notes'))
-			except ConfigParser.NoOptionError:
-				tkMessageBox.showwarning("Bad config file",
+			except configparser.NoOptionError:
+				tkinter.messagebox.showwarning("Bad config file",
 						"Configuration file corrupt."\
 						" Please update your configuration.")
 				self.edit_configuration(cancellable=False)
@@ -490,16 +490,16 @@ class Configuration(M3Gui):
 			cs = cs_var_new.get()
 			notes = notes_text.get(1.0, Tk.END).strip()
 			if ws[0] == '<':
-				tkMessageBox.showerror("No Workstation Selected",
+				tkinter.messagebox.showerror("No Workstation Selected",
 						"Please select a workstation")
 				return
 			if cs[0] == '<':
-				tkMessageBox.showerror("No Chips / Stack Selected",
+				tkinter.messagebox.showerror("No Chips / Stack Selected",
 						"Please select the chips / stacks you are currently"\
 						" using for testing.")
 				return
 			if len(notes) < 10 or notes.strip() == default_notes:
-				tkMessageBox.showerror("No testing notes added",
+				tkinter.messagebox.showerror("No testing notes added",
 						"Please add some notes on what you are currently"\
 						" working on. Add some detail -- it may be important"\
 						" for you to be able to look this up in the future")
@@ -547,11 +547,11 @@ class Configuration(M3Gui):
 		edit.protocol("WM_DELETE_WINDOW", exit_handler)
 		edit.bind("<Escape>", lambda event : exit_handler())
 
-		label = ttk.Label(edit,
+		label = tkinter.ttk.Label(edit,
 				text="Editing configuration for " + self.uniqname_var.get())
 		label.grid(row=0, columnspan=2)
 
-		ws_label = ttk.Label(edit, text="Workstation")
+		ws_label = tkinter.ttk.Label(edit, text="Workstation")
 		ws_label.grid(row=1, column=0, sticky='e')
 
 		ws_var_new = Tk.StringVar(edit)
@@ -565,13 +565,13 @@ class Configuration(M3Gui):
 					continue
 				ws_list.append(line)
 		except IOError:
-			tkMessageBox.showerror('Missing Workstation List',
+			tkinter.messagebox.showerror('Missing Workstation List',
 					'Configs directory is missing required file:'\
 					' "workstations.txt".')
 			self.parent.destroy()
 			sys.exit()
 		if len(ws_list) == 0:
-			tkMessageBox.showerror('Empty Workstation List',
+			tkinter.messagebox.showerror('Empty Workstation List',
 					'There must be at least one entry in workstations.txt')
 			self.parent.destroy()
 			sys.exit()
@@ -580,7 +580,7 @@ class Configuration(M3Gui):
 
 		try:
 			ws_var_new.set(self.config.get('DEFAULT', 'workstation'))
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			ws_var_new.set('< Select Workstation >')
 			if not focused:
 				ws_option.focus_set()
@@ -594,7 +594,7 @@ class Configuration(M3Gui):
 					return r
 				l = '\n'.join(s(chips_tree) + s(stacks_tree))
 				if len(l) == 0:
-					tkMessageBox.showerror('No Chips Selected', 'You must'\
+					tkinter.messagebox.showerror('No Chips Selected', 'You must'\
 							' select at least on chip or stack.')
 					return
 				selected_label.set(l)
@@ -623,13 +623,13 @@ class Configuration(M3Gui):
 									except ValueError:
 										start = s
 										end = s
-									for i in xrange(int(start), int(end)+1):
+									for i in range(int(start), int(end)+1):
 										ll.append("{}".format(i))
 								l.append((txt, ll))
 							except:
 								logger.warn("Ignoring bad chip/stack entry: " + line)
 				except IOError:
-					tkMessageBox.showerror('Missing Chip / Stack List',
+					tkinter.messagebox.showerror('Missing Chip / Stack List',
 							'Configs directory is missing required file: ' + f)
 					self.parent.destroy()
 					sys.exit()
@@ -642,18 +642,18 @@ class Configuration(M3Gui):
 			stacks = parse_cs_file(stacksf)
 
 			if (len(chips) is 0) and (len(stacks) is 0):
-				tkMessageBox.showerror("Empty Chips and Stacks",
+				tkinter.messagebox.showerror("Empty Chips and Stacks",
 						'At least one chip or stack must be defined.'\
 								' Both chips.txt and stacks.txt are empty.')
 				self.parent.destroy()
 				sys.exit()
 
-			title = ttk.Label(selector, text="Select the chips and / or"\
+			title = tkinter.ttk.Label(selector, text="Select the chips and / or"\
 					" stacks you are currently testing. Hold the Shift or"\
 					" Control keys to select multiple.")
 			title.grid(row=0, columnspan=2, stick='we')
 
-			chips_tree = ttk.Treeview(selector, height=40)
+			chips_tree = tkinter.ttk.Treeview(selector, height=40)
 			for model, numbers in chips:
 				chips_tree.insert('', 'end', model, text=model, open=True)
 				for n in numbers:
@@ -661,7 +661,7 @@ class Configuration(M3Gui):
 					chips_tree.insert(model, 'end', name, text=name)
 			chips_tree.grid(row=1, column=0, sticky='ns')
 
-			stacks_tree = ttk.Treeview(selector, height=40)
+			stacks_tree = tkinter.ttk.Treeview(selector, height=40)
 			for model, numbers in stacks:
 				stacks_tree.insert('', 'end', model, text=model, open=True)
 				for n in numbers:
@@ -686,12 +686,12 @@ class Configuration(M3Gui):
 			cancel.grid(row=3, column=0, sticky='e')
 
 
-		cs_label = ttk.Label(edit, text="Chips / Stacks")
+		cs_label = tkinter.ttk.Label(edit, text="Chips / Stacks")
 		cs_label.grid(row=2, column=0, sticky='ne')
 
 		cs_var_new = Tk.StringVar(edit)
 
-		cs_active_label = ttk.Label(edit, textvariable=cs_var_new)
+		cs_active_label = tkinter.ttk.Label(edit, textvariable=cs_var_new)
 		cs_active_label.grid(row=2, column=1)
 
 		cs_btn = ButtonWithReturns(edit, text="Select Chips / Stacks",
@@ -700,13 +700,13 @@ class Configuration(M3Gui):
 
 		try:
 			cs_var_new.set(self.config.get('DEFAULT', 'chips'))
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			cs_var_new.set('< No Chips / Stacks Selected >')
 			if not focused:
 				cs_btn.focus_set()
 				focused = True
 
-		notes_label = ttk.Label(edit, text="Notes:")
+		notes_label = tkinter.ttk.Label(edit, text="Notes:")
 		notes_label.grid(row=4, columnspan=2, sticky='w')
 
 		notes_text = Tk.Text(edit)
@@ -715,7 +715,7 @@ class Configuration(M3Gui):
 
 		try:
 			notes_text.insert(Tk.INSERT, self.config.get('DEFAULT', 'notes'))
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			notes_text.insert(Tk.INSERT, default_notes)
 			if not focused:
 				notes_text.focus_set()
@@ -746,7 +746,7 @@ class ConfigPane(M3Gui):
 		if hasattr(self.configuration, 'quit'):
 			sys.exit()
 
-		self.config_container = ttk.Frame(parent,
+		self.config_container = tkinter.ttk.Frame(parent,
 				height=800,
 				width=200,
 				borderwidth=5,
@@ -767,23 +767,23 @@ class ConfigPane(M3Gui):
 				self.configuration.edit_configuration(cancellable=True),
 				).pack(fill=Tk.X)
 
-		ttk.Label(self.config_container, text="User:").pack(anchor='w')
-		self.user_label = ttk.Label(self.config_container,
+		tkinter.ttk.Label(self.config_container, text="User:").pack(anchor='w')
+		self.user_label = tkinter.ttk.Label(self.config_container,
 			textvariable=self.configuration.uniqname_var)
 		self.user_label.pack(padx='5m', anchor='w')
 
-		ttk.Label(self.config_container, text="Workstation:").pack(anchor='w')
+		tkinter.ttk.Label(self.config_container, text="Workstation:").pack(anchor='w')
 		self.ws_label = Tk.Label(self.config_container,
 				textvariable=self.configuration.ws_var)
 		self.ws_label.pack(padx='5m', anchor='w')
 
-		ttk.Label(self.config_container, text="Chips / Stacks:").pack(anchor='w')
-		self.chips_label = ttk.Label(self.config_container,
+		tkinter.ttk.Label(self.config_container, text="Chips / Stacks:").pack(anchor='w')
+		self.chips_label = tkinter.ttk.Label(self.config_container,
 			textvariable=self.configuration.cs_var)
 		self.chips_label.pack(padx='5m', anchor='w')
 
-		ttk.Label(self.config_container, text="Notes:").pack(anchor='w')
-		self.notes_label = ttk.Label(self.config_container,
+		tkinter.ttk.Label(self.config_container, text="Notes:").pack(anchor='w')
+		self.notes_label = tkinter.ttk.Label(self.config_container,
 			textvariable=self.configuration.notes_var, wraplength=150)
 		self.notes_label.pack(padx='5m', anchor='w')
 
@@ -792,9 +792,9 @@ class ConfigPane(M3Gui):
 			self.lastup_var.set(pretty_time(self.configuration.last_updated))
 		else:
 			self.lastup_var.set('Error! Corrupt configuration file')
-		self.lastup_label = ttk.Label(self.config_container, textvariable=self.lastup_var)
+		self.lastup_label = tkinter.ttk.Label(self.config_container, textvariable=self.lastup_var)
 		self.lastup_label.pack(side=Tk.BOTTOM, padx='5m', anchor='sw')
-		ttk.Label(self.config_container, text="Config Last Updated:").pack(side=Tk.BOTTOM, anchor='sw')
+		tkinter.ttk.Label(self.config_container, text="Config Last Updated:").pack(side=Tk.BOTTOM, anchor='sw')
 
 class MainPane(M3Gui):
 	def __init__(self, parent, args, config):
@@ -802,7 +802,7 @@ class MainPane(M3Gui):
 		self.args = args
 		self.config = config
 
-		self.mainpane = ttk.Frame(parent,
+		self.mainpane = tkinter.ttk.Frame(parent,
 				borderwidth=5,
 				relief=Tk.RIDGE,
 				height=800,
@@ -821,18 +821,18 @@ class MainPane(M3Gui):
 		self.on_ice_connect = []
 		self.on_ice_disconnect = []
 
-		self.async_event_queue = Queue.Queue()
+		self.async_event_queue = queue.Queue()
 		def async_event_handler():
 			try:
 				while True:
 					self.async_event_queue.get_nowait()()
-			except Queue.Empty:
+			except queue.Empty:
 				pass
 			self.parent.after(50, async_event_handler)
 		self.parent.after_idle(async_event_handler)
 
 		# Bar holding ICE status / info / etc
-		self.icepane = ttk.LabelFrame(self.mainpane, text="ICE")
+		self.icepane = tkinter.ttk.LabelFrame(self.mainpane, text="ICE")
 		self.icepane.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY,
 				ipadx=self.FRAME_IPADX, ipady=self.FRAME_IPADY)
@@ -915,7 +915,7 @@ class MainPane(M3Gui):
 				if last_serial not in port_list:
 					port_list.insert(0, last_serial)
 				self.port_selector_var.set(last_serial)
-			except (ConfigParser.NoOptionError, ValueError):
+			except (configparser.NoOptionError, ValueError):
 				if hasattr(self, 'ice') and self.ice.is_connected():
 					self.port_selector_var.set(self.ice.dev.portstr)
 				else:
@@ -932,17 +932,17 @@ class MainPane(M3Gui):
 
 		self.port_selector_var = Tk.StringVar()
 		self.port_selector_var.trace('w', serial_port_changed)
-		self.port_selector = ttk.OptionMenu(self.icepane, self.port_selector_var)
+		self.port_selector = tkinter.ttk.OptionMenu(self.icepane, self.port_selector_var)
 		populate_serial_port_list()
 		self.port_selector.pack(side=Tk.LEFT)
 
 		self.ice_status_var = Tk.StringVar()
 		self.ice_status_var.set('Not connected to ICE')
-		ttk.Label(self.icepane, textvariable=self.ice_status_var
+		tkinter.ttk.Label(self.icepane, textvariable=self.ice_status_var
 				).pack(fill='y', expand=1, anchor='e')
 
 		# Bar with Power control information
-		self.powerpane = ttk.LabelFrame(self.mainpane, text="Power Control")
+		self.powerpane = tkinter.ttk.LabelFrame(self.mainpane, text="Power Control")
 		self.powerpane.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
@@ -964,8 +964,8 @@ class MainPane(M3Gui):
 			if onoff or force_settle:
 				win = ModalWindow(self.parent)
 				win.title = "Applying power setting"
-				ttk.Label(win, text="Waiting for power rail to settle...").pack()
-				pb = ttk.Progressbar(win, length=300, maximum=settle_time/ .050)
+				tkinter.ttk.Label(win, text="Waiting for power rail to settle...").pack()
+				pb = tkinter.ttk.Progressbar(win, length=300, maximum=settle_time/ .050)
 				pb.pack()
 				pb.start()
 				win.after(settle_time * 1000, lambda : win.destroy())
@@ -984,7 +984,7 @@ class MainPane(M3Gui):
 			def apply_cfg(rail, key, dfl, var):
 				try:
 					voltage = self.config.getfloat('DEFAULT', key)
-				except ConfigParser.NoOptionError:
+				except configparser.NoOptionError:
 					voltage = dfl
 				apply_voltage(rail, voltage, False, var)
 
@@ -1002,9 +1002,9 @@ class MainPane(M3Gui):
 			for v in (self.power0P6_var, self.power1P2_var, self.powervbatt_var):
 				v.set('ICE disconnected')
 
-		self.powerframe1 = ttk.Frame(self.powerpane)
+		self.powerframe1 = tkinter.ttk.Frame(self.powerpane)
 		self.powerframe1.pack(fill='x', expand=1)
-		ttk.Label(self.powerframe1, text="0.6 V Rail:").pack(side='left')
+		tkinter.ttk.Label(self.powerframe1, text="0.6 V Rail:").pack(side='left')
 		self.power0P6_onoff = Tk.IntVar()
 		self.power0P6_onoff.set(0)
 		self.power0P6_off = Tk.Radiobutton(self.powerframe1, text="Off",
@@ -1017,7 +1017,7 @@ class MainPane(M3Gui):
 						apply_power_onoff(self.ice.POWER_0P6, True,
 							self.power0P6_on, self.power0P6_var))
 		self.power0P6_on.pack(side='left')
-		self.power0P6_entry = ttk.Entry(self.powerframe1)
+		self.power0P6_entry = tkinter.ttk.Entry(self.powerframe1)
 		add_returns(self.power0P6_entry,
 				lambda : apply_voltage(self.ice.POWER_0P6, self.power0P6_entry.get(),
 					self.power0P6_onoff.get(), self.power0P6_var))
@@ -1029,11 +1029,11 @@ class MainPane(M3Gui):
 		self.power0P6_btn.pack(side='left')
 		self.power0P6_var = Tk.StringVar()
 		self.power0P6_var.set('ICE disconnected')
-		ttk.Label(self.powerframe1, textvariable=self.power0P6_var).pack(anchor='e')
+		tkinter.ttk.Label(self.powerframe1, textvariable=self.power0P6_var).pack(anchor='e')
 
-		self.powerframe2 = ttk.Frame(self.powerpane)
+		self.powerframe2 = tkinter.ttk.Frame(self.powerpane)
 		self.powerframe2.pack(fill='x', expand=1)
-		ttk.Label(self.powerframe2, text="1.2 V Rail:").pack(side='left')
+		tkinter.ttk.Label(self.powerframe2, text="1.2 V Rail:").pack(side='left')
 		self.power1P2_onoff = Tk.IntVar()
 		self.power1P2_onoff.set(0)
 		self.power1P2_off = Tk.Radiobutton(self.powerframe2, text="Off",
@@ -1046,7 +1046,7 @@ class MainPane(M3Gui):
 						apply_power_onoff(self.ice.POWER_1P2, True,
 							self.power1P2_on, self.power1P2_var))
 		self.power1P2_on.pack(side='left')
-		self.power1P2_entry = ttk.Entry(self.powerframe2)
+		self.power1P2_entry = tkinter.ttk.Entry(self.powerframe2)
 		add_returns(self.power1P2_entry,
 				lambda : apply_voltage(self.ice.POWER_1P2, self.power1P2_entry.get(),
 					self.power1P2_onoff.get(), self.power1P2_var))
@@ -1058,11 +1058,11 @@ class MainPane(M3Gui):
 		self.power1P2_btn.pack(side='left')
 		self.power1P2_var = Tk.StringVar()
 		self.power1P2_var.set('ICE disconnected')
-		ttk.Label(self.powerframe2, textvariable=self.power1P2_var).pack(anchor='e')
+		tkinter.ttk.Label(self.powerframe2, textvariable=self.power1P2_var).pack(anchor='e')
 
-		self.powerframe3 = ttk.Frame(self.powerpane)
+		self.powerframe3 = tkinter.ttk.Frame(self.powerpane)
 		self.powerframe3.pack(fill='x', expand=1)
-		ttk.Label(self.powerframe3, text="VBatt Rail:").pack(side='left')
+		tkinter.ttk.Label(self.powerframe3, text="VBatt Rail:").pack(side='left')
 		self.powervbatt_onoff = Tk.IntVar()
 		self.powervbatt_onoff.set(0)
 		self.powervbatt_off = Tk.Radiobutton(self.powerframe3, text="Off",
@@ -1075,7 +1075,7 @@ class MainPane(M3Gui):
 						apply_power_onoff(self.ice.POWER_VBATT, True,
 							self.powervbatt_on, self.powervbatt_var))
 		self.powervbatt_on.pack(side='left')
-		self.powervbatt_entry = ttk.Entry(self.powerframe3)
+		self.powervbatt_entry = tkinter.ttk.Entry(self.powerframe3)
 		add_returns(self.powervbatt_entry,
 				lambda : apply_voltage(self.ice.POWER_VBATT, self.powervbatt_entry.get(),
 					self.powervbatt_onoff.get(), self.powervbatt_var))
@@ -1087,7 +1087,7 @@ class MainPane(M3Gui):
 		self.powervbatt_btn.pack(side='left')
 		self.powervbatt_var = Tk.StringVar()
 		self.powervbatt_var.set('ICE disconnected')
-		ttk.Label(self.powerframe3, textvariable=self.powervbatt_var).pack(anchor='e')
+		tkinter.ttk.Label(self.powerframe3, textvariable=self.powervbatt_var).pack(anchor='e')
 
 		self.on_ice_connect.append(on_ice_connect_power)
 		self.on_ice_disconnect.append(on_ice_disconnect_power)
@@ -1114,7 +1114,7 @@ class MainPane(M3Gui):
 			apply_power_onoff(self.ice.POWER_0P6, True, self.power0P6_on,
 					self.power0P6_var, force_settle=True)
 
-		self.powerframe4 = ttk.Frame(self.powerpane)
+		self.powerframe4 = tkinter.ttk.Frame(self.powerpane)
 		self.powerframe4.pack(fill='x', expand=1)
 		ButtonWithReturns(self.powerframe4, text="Run M3 Reset Sequence",
 				command = reset_sequence).pack(side='right')
@@ -1124,7 +1124,7 @@ class MainPane(M3Gui):
 				command = power_all_off).pack(side='right')
 
 		# Bar with GOC configuration
-		self.gocpane = ttk.LabelFrame(self.mainpane, text="GOC Configuration")
+		self.gocpane = tkinter.ttk.LabelFrame(self.mainpane, text="GOC Configuration")
 		self.gocpane.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
@@ -1145,17 +1145,17 @@ class MainPane(M3Gui):
 			logger.debug('on_ice_connect_goc_freq')
 			try:
 				apply_goc_freq(self.config.getfloat('DEFAULT', 'goc_freq'))
-			except ConfigParser.NoOptionError:
+			except configparser.NoOptionError:
 				apply_goc_freq(None)
 
-		self.gocframe1 = ttk.Frame(self.gocpane)
+		self.gocframe1 = tkinter.ttk.Frame(self.gocpane)
 		self.gocframe1.pack(fill='x', expand=1)
-		ttk.Label(self.gocframe1, text="Slow Frequency: ").pack(side='left')
-		self.goc_freq_entry = ttk.Entry(self.gocframe1)
+		tkinter.ttk.Label(self.gocframe1, text="Slow Frequency: ").pack(side='left')
+		self.goc_freq_entry = tkinter.ttk.Entry(self.gocframe1)
 		add_returns(self.goc_freq_entry,
 				lambda : apply_goc_freq(self.goc_freq_entry.get()))
 		self.goc_freq_entry.pack(side='left')
-		ttk.Label(self.gocframe1, text="Hz").pack(side='left')
+		tkinter.ttk.Label(self.gocframe1, text="Hz").pack(side='left')
 		self.goc_freq_btn = ButtonWithReturns(self.gocframe1, text="Apply",
 				command=lambda : apply_goc_freq(self.goc_freq_entry.get()))
 		self.goc_freq_btn.pack(side='left')
@@ -1164,7 +1164,7 @@ class MainPane(M3Gui):
 		self.on_ice_connect.append(on_ice_connect_goc_freq)
 		self.on_ice_disconnect.append(lambda :\
 				self.goc_freq_var.set('ICE disconnected'))
-		ttk.Label(self.gocframe1, textvariable=self.goc_freq_var).pack(anchor='e')
+		tkinter.ttk.Label(self.gocframe1, textvariable=self.goc_freq_var).pack(anchor='e')
 
 		def apply_goc_pol(is_normal):
 			if is_normal:
@@ -1190,12 +1190,12 @@ class MainPane(M3Gui):
 					apply_goc_pol(True)
 				else:
 					apply_goc_pol(False)
-			except ConfigParser.NoOptionError:
+			except configparser.NoOptionError:
 				apply_goc_pol(not self.ice.goc_get_onoff())
 
-		self.gocframe2 = ttk.Frame(self.gocpane)
+		self.gocframe2 = tkinter.ttk.Frame(self.gocpane)
 		self.gocframe2.pack(fill='x', expand=1)
-		ttk.Label(self.gocframe2, text="Polarity: ").pack(side='left')
+		tkinter.ttk.Label(self.gocframe2, text="Polarity: ").pack(side='left')
 		self.goc_pol_var = Tk.IntVar()
 		self.goc_pol_var.set(0)
 		self.goc_pol_normal = Tk.Radiobutton(self.gocframe2, text="Normal",
@@ -1211,19 +1211,19 @@ class MainPane(M3Gui):
 		self.on_ice_connect.append(on_ice_connect_goc_pol)
 		self.on_ice_disconnect.append(lambda :\
 				self.goc_pol_lbl.set('ICE disconnected'))
-		ttk.Label(self.gocframe2, textvariable=self.goc_pol_lbl).pack(anchor='e')
+		tkinter.ttk.Label(self.gocframe2, textvariable=self.goc_pol_lbl).pack(anchor='e')
 
 		# Bar holding program image / etc
-		self.progpane = ttk.LabelFrame(self.mainpane, text="Program")
+		self.progpane = tkinter.ttk.LabelFrame(self.mainpane, text="Program")
 		self.progpane.pack(fill=Tk.X, expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
-		self.progframe = ttk.Frame(self.progpane)
+		self.progframe = tkinter.ttk.Frame(self.progpane)
 		self.progframe.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
 		def prog_changed():
-			new_file = tkFileDialog.askopenfilename(
+			new_file = tkinter.filedialog.askopenfilename(
 					filetypes=(
 						('program', '*.bin'),
 						('program', '*.hex'),
@@ -1271,19 +1271,19 @@ class MainPane(M3Gui):
 				change_file(None, True)
 
 		self.prog_button_var = Tk.StringVar()
-		self.prog_button = ttk.Button(self.progframe,
+		self.prog_button = tkinter.ttk.Button(self.progframe,
 				textvariable=self.prog_button_var, command=prog_changed)
 		self.prog_button.pack(side=Tk.LEFT)
 
 		self.prog_info_var = Tk.StringVar()
-		ttk.Label(self.progframe, textvariable=self.prog_info_var,
+		tkinter.ttk.Label(self.progframe, textvariable=self.prog_info_var,
 				justify=Tk.RIGHT).pack(fill='y', expand=1, anchor='e')
 
-		self.progactionframe = ttk.Frame(self.progpane)
+		self.progactionframe = tkinter.ttk.Frame(self.progpane)
 		self.progactionframe.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
-		ttk.Label(self.progactionframe, text='Run After Programming:'
+		tkinter.ttk.Label(self.progactionframe, text='Run After Programming:'
 				).pack(side='left')
 		self.prog_run_after_var = Tk.IntVar()
 		self.prog_run_after_yes = Tk.Radiobutton(self.progactionframe,
@@ -1299,7 +1299,7 @@ class MainPane(M3Gui):
 
 		try:
 			runafter = self.config.getboolean('DEFAULT', 'prog_run_after')
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			runafter = True
 		if runafter:
 			self.prog_run_after_yes.select()
@@ -1373,7 +1373,7 @@ class MainPane(M3Gui):
 				c2 = Tk.Checkbutton(goc_win, #state=Tk.DISABLED,
 						text="Wake chip via GOC")
 				c2.pack(fill='x', expand=1, anchor='w')
-				p2 = ttk.Progressbar(goc_win, length=300,
+				p2 = tkinter.ttk.Progressbar(goc_win, length=300,
 						maximum=((2*8)/slow_freq)/.050)
 				p2.pack()
 				fns.append((c2, p2, lambda :\
@@ -1382,7 +1382,7 @@ class MainPane(M3Gui):
 				c6 = Tk.Checkbutton(goc_win, #state=Tk.DISABLED,
 						text="Delay for ~2 sec")
 				c6.pack(fill='x', expand=1, anchor='w')
-				p6 = ttk.Progressbar(goc_win, length=300, maximum=(2/.050))
+				p6 = tkinter.ttk.Progressbar(goc_win, length=300, maximum=(2/.050))
 				p6.pack()
 				fns.append((c6, p6, lambda : time.sleep(2)))
 
@@ -1396,7 +1396,7 @@ class MainPane(M3Gui):
 			c4 = Tk.Checkbutton(goc_win, #state=Tk.DISABLED,
 					text="Send GOC message (~{} seconds)".format(est_time))
 			c4.pack(fill='x', expand=1, anchor='w')
-			p4 = ttk.Progressbar(goc_win, length=300, maximum=(est_time/.050))
+			p4 = tkinter.ttk.Progressbar(goc_win, length=300, maximum=(est_time/.050))
 			p4.pack()
 			fns.append((c4, p4, lambda m=message:\
 					self.ice.goc_send(m, False)))
@@ -1404,7 +1404,7 @@ class MainPane(M3Gui):
 			c5 = Tk.Checkbutton(goc_win, #state=Tk.DISABLED,
 					text="Send extra blink to end transaction")
 			c5.pack(fill='x', expand=1, anchor='w')
-			p5 = ttk.Progressbar(goc_win, length=300,
+			p5 = tkinter.ttk.Progressbar(goc_win, length=300,
 					maximum=((2*8)/(8*slow_freq))/.050)
 			p5.pack()
 			fns.append((c5, p5, lambda :\
@@ -1453,7 +1453,7 @@ class MainPane(M3Gui):
 					logger.debug("Running: " + ' '.join(cmd))
 					try:
 						output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-					except subprocess.CalledProcessError, e:
+					except subprocess.CalledProcessError as e:
 						logger.warn('Build failure. Command was: ' + ' '.join(cmd))
 						logger.warn('Build output:\n' + e.output[:-1])
 						raise
@@ -1476,7 +1476,7 @@ class MainPane(M3Gui):
 								pass
 					new_bd, new_pd = os.path.split(base_dir)
 					if new_bd == base_dir:
-						tkMessageBox.showerror('Build Error',
+						tkinter.messagebox.showerror('Build Error',
 								'Compilation failed. Check output window for details.')
 						break
 					else:
@@ -1490,7 +1490,7 @@ class MainPane(M3Gui):
 				if os.path.getmtime(prog) < os.path.getmtime(source):
 					win = ModalWindow(self.parent)
 					win.title('Program out of date')
-					ttk.Label(win, text='Program source is older than program.'\
+					tkinter.ttk.Label(win, text='Program source is older than program.'\
 							' Would you like to re-compile before loading?').pack()
 					ButtonWithReturnsAndEscape(win, text="No", command = lambda :\
 							win.destroy()).pack(side='right')
@@ -1514,7 +1514,7 @@ class MainPane(M3Gui):
 							cwd = os.path.dirname(source),
 							)
 					logger.info(name + ' revision: ' + output)
-				except subprocess.CalledProcessError, e:
+				except subprocess.CalledProcessError as e:
 					logger.warn('Failed to get current revision. Command was: '+\
 							' '.join(cmd))
 					logger.warn('Command output:\n' + e.output[:-1])
@@ -1530,7 +1530,7 @@ class MainPane(M3Gui):
 						logger.info(name + ' has uncommitted changes:\n' + output)
 					else:
 						logger.debug(name + ' has no uncommitted changes.')
-				except subprocess.CalledProcessError, e:
+				except subprocess.CalledProcessError as e:
 					logger.warn('Failed to get diff. Command was: '+ ' '.join(cmd))
 					logger.warn('Command output:\n' + e.output[:-1])
 			else:
@@ -1552,11 +1552,11 @@ class MainPane(M3Gui):
 
 		try:
 			change_file(self.config.get('DEFAULT', 'program'))
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			change_file('', force_select=True)
 
 		# Bar with commands
-		self.messagepane = ttk.LabelFrame(self.mainpane, text="Custom Messages")
+		self.messagepane = tkinter.ttk.LabelFrame(self.mainpane, text="Custom Messages")
 		self.messagepane.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
@@ -1601,33 +1601,33 @@ class MainPane(M3Gui):
 				self.message_send_goc.configure(state=Tk.NORMAL)
 				self.message_send_goc_no_wakeup.configure(state=Tk.NORMAL)
 
-		self.messageframe = ttk.Frame(self.messagepane)
+		self.messageframe = tkinter.ttk.Frame(self.messagepane)
 		self.messageframe.pack(fill='x', expand=1)
-		ttk.Label(self.messageframe, text='Address').pack(side='left')
-		self.message_addr = ttk.Entry(self.messageframe)
+		tkinter.ttk.Label(self.messageframe, text='Address').pack(side='left')
+		self.message_addr = tkinter.ttk.Entry(self.messageframe)
 		self.message_addr.pack(side='left')
 		self.message_addr.bind('<Key>', lambda e :\
 				self.message_addr.after_idle(validate_command))
-		ttk.Label(self.messageframe, text='Data').pack(side='left')
-		self.message_data = ttk.Entry(self.messageframe)
+		tkinter.ttk.Label(self.messageframe, text='Data').pack(side='left')
+		self.message_data = tkinter.ttk.Entry(self.messageframe)
 		self.message_data.pack(side='left')
 		self.message_data.bind('<Key>', lambda e :\
 				self.message_data.after_idle(validate_command))
-		ttk.Label(self.messageframe, text='(All values hex)').pack(side='left')
+		tkinter.ttk.Label(self.messageframe, text='(All values hex)').pack(side='left')
 
 		self.message_contents_var = Tk.StringVar()
 		self.message_contents_var.set("Empty Address")
-		ttk.Label(self.messageframe, textvariable=self.message_contents_var
+		tkinter.ttk.Label(self.messageframe, textvariable=self.message_contents_var
 				).pack(side='right')
 
-		self.messageactionframe = ttk.Frame(self.messagepane)
+		self.messageactionframe = tkinter.ttk.Frame(self.messagepane)
 		self.messageactionframe.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
 		def select_preprogrammed_command(cmd):
 			if cmd == 'Select Common Message...':
 				return
-			addr, data = map(str.strip, cmd.split('(')[1][:-1].split(','))
+			addr, data = list(map(str.strip, cmd.split('(')[1][:-1].split(',')))
 			self.message_addr.delete(0, Tk.END)
 			self.message_addr.insert(0, addr[2:])
 			self.message_data.delete(0, Tk.END)
@@ -1641,7 +1641,7 @@ class MainPane(M3Gui):
 				"SNS Sample Setup   (0x40, 0x030bf0f0)",
 				"SNS Sample Start   (0x40, 0x030af0f0)",
 				)
-		self.message_defaults = ttk.OptionMenu(self.messageactionframe,
+		self.message_defaults = tkinter.ttk.OptionMenu(self.messageactionframe,
 				self.message_defaults_var, *default_messages,
 				command = select_preprogrammed_command)
 		self.message_defaults.pack(side='left')
@@ -1682,7 +1682,7 @@ class MainPane(M3Gui):
 		self.message_send_goc_no_wakeup.pack(side='right')
 
 		# Interface for live session
-		self.actionpane = ttk.LabelFrame(self.mainpane, text='Action Pane')
+		self.actionpane = tkinter.ttk.LabelFrame(self.mainpane, text='Action Pane')
 		self.actionpane.pack(fill='both', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
@@ -1706,14 +1706,14 @@ class MainPane(M3Gui):
 				self.window.tag_config( 'err', foreground='red')
 				self.window.tag_config( 'dbg', foreground='cyan')
 
-				self.queue = Queue.Queue()
+				self.queue = queue.Queue()
 				self.process_events()
 
 			def process_events(self):
 				try:
 					while True:
 						self.queue.get_nowait()()
-				except Queue.Empty:
+				except queue.Empty:
 					pass
 				self.window.after(100, self.process_events)
 
@@ -1775,7 +1775,7 @@ class MainPane(M3Gui):
 		# modify the logging configuration to add our handler as another
 		# handler that is installed by default. But I don't know how to do that
 		# and it doesn't matter yet, so... tomorrow Pat's problem.
-		for l in logging.Logger.manager.loggerDict.values():
+		for l in list(logging.Logger.manager.loggerDict.values()):
 			l.addHandler(self.terminal_logger_handler)
 
 		# Monitor window for MBus messages
@@ -1804,7 +1804,7 @@ def setup_file_logger(config_file, uniq):
 	file_handler = SyncingFileHandler(logfile, delay=True)
 	file_handler.level = logging.DEBUG
 	file_handler.formatter = file_formatter
-	for l in logging.Logger.manager.loggerDict.values():
+	for l in list(logging.Logger.manager.loggerDict.values()):
 		l.addHandler(file_handler)
 	setup_file_logger.logfile = logfile
 
@@ -1816,8 +1816,8 @@ if __name__ == '__main__':
 
 	root = Tk.Tk()
 
-	style = ttk.Style()
-	ttk.Style().theme_use('alt')
+	style = tkinter.ttk.Style()
+	tkinter.ttk.Style().theme_use('alt')
 
 	#print(style.layout('TLabel'))
 	#print(style.element_options('Label.border'))

--- a/platforms/HT_m3/programming/ice.py
+++ b/platforms/HT_m3/programming/ice.py
@@ -15,7 +15,7 @@ logger.debug('Got ice.py logger')
 
 try:
     import threading
-    import Queue
+    import queue
 except ImportError:
     logger.warn("Your python installation does not support threads.")
     logger.warn("")
@@ -98,10 +98,10 @@ class ICE(object):
         def wrapped_fn_factory(fn_being_decorated):
             def wrapped_fn(self, *args, **kwargs):
                 if not hasattr(self, "minor"):
-                    raise self.ICE_Error, "ICE must be connected first"
-                major, minor = map(int, version.split('.'))
+                    raise self.ICE_Error("ICE must be connected first")
+                major, minor = list(map(int, version.split('.')))
                 if major != 0:
-                    raise self.ICE_Error, "Major version bump?"
+                    raise self.ICE_Error("Major version bump?")
                 if self.minor < minor:
                     raise self.VersionError(minor, self.minor)
                 return fn_being_decorated(self, *args, **kwargs)
@@ -117,10 +117,10 @@ class ICE(object):
         def wrapped_fn_factory(fn_being_decorated):
             def wrapped_fn(self, *args, **kwargs):
                 if not hasattr(self, "minor"):
-                    raise self.ICE_Error, "ICE must be connected first"
-                major, minor = map(int, version.split('.'))
+                    raise self.ICE_Error("ICE must be connected first")
+                major, minor = list(map(int, version.split('.')))
                 if major != 0:
-                    raise self.ICE_Error, "Major version bump?"
+                    raise self.ICE_Error("Major version bump?")
                 if self.minor > minor:
                     raise self.VersionError(minor, self.minor)
                 return fn_being_decorated(self, *args, **kwargs)
@@ -156,7 +156,7 @@ class ICE(object):
 
         self.event_id = 0
         self.last_event_id = -1
-        self.sync_queue = Queue.Queue(1)
+        self.sync_queue = queue.Queue(1)
 
         self.msg_handler = {}
         self.d_lock = threading.Lock()
@@ -185,7 +185,7 @@ class ICE(object):
         if self.dev.isOpen():
             logger.info("Connected to serial device at " + self.dev.portstr)
         else:
-            raise self.ICE_Error, "Failed to connect to serial device"
+            raise self.ICE_Error("Failed to connect to serial device")
 
         self.communicator_stop_request = threading.Event()
         self.communicator_stop_response = threading.Event()
@@ -220,7 +220,7 @@ class ICE(object):
             logger.warn("WARNING: No handler registered for message type: " +
                     str(msg_type))
             logger.warn("Known Types:")
-            for t,f in self.msg_handler.iteritems():
+            for t,f in self.msg_handler.items():
                 logger.warn("%s\t%s" % (t, str(f)))
             logger.warn("         Dropping packet:")
             logger.warn("")
@@ -263,7 +263,7 @@ class ICE(object):
                     else:
                         logger.info("Got a NAK packet. Event:" + str(event_id))
                     self.sync_queue.put((msg_type, msg))
-                except Queue.Full:
+                except queue.Full:
                     logger.warn("WARNING: Synchronization lost. Unsolicited ACK/NAK.")
                     logger.warn("         Dropping packet:")
                     logger.warn("")
@@ -293,16 +293,16 @@ class ICE(object):
             elif c in ('x', 'X'):
                 continue
             else:
-                raise self.FormatError, "Illegal character: >>>" + c + "<<<"
+                raise self.FormatError("Illegal character: >>>" + c + "<<<")
         return ones,zeros
 
     def masks_to_strings(self, ones, zeros, length):
         s = ''
-        for l in xrange(length):
+        for l in range(length):
             o = bool(ones & (1 << l))
             z = bool(zeros & (1 << l))
             if o and z:
-                raise self.FormatError, "masks_to_strings has req 1 and req 0?"
+                raise self.FormatError("masks_to_strings has req 1 and req 0?")
             if o:
                 s = '1' + s
             elif z:
@@ -439,10 +439,10 @@ class ICE(object):
 
     def send_message(self, msg_type, msg='', length=None):
         if len(msg_type) != 1:
-            raise self.FormatError, "msg_type must be exactly 1 character"
+            raise self.FormatError("msg_type must be exactly 1 character")
 
         if len(msg) > 255:
-            raise self.FormatError, "msg too long. Maximum msg is 255 bytes"
+            raise self.FormatError("msg too long. Maximum msg is 255 bytes")
 
         if length is None:
             length = len(msg)
@@ -478,7 +478,7 @@ class ICE(object):
         logger.debug("Sending version probe")
         resp = self.send_message_until_acked('V')
         if (len(resp) is 0) or (len(resp) % 2):
-            raise self.FormatError, "Version response: " + resp
+            raise self.FormatError("Version response: " + resp)
 
         logger.info("This ICE board supports versions...")
         self.major = None
@@ -581,7 +581,7 @@ class ICE(object):
         elif div == 0x0007:
             return 3000000
         else:
-            raise self.FormatError, "Unknown baud divider?"
+            raise self.FormatError("Unknown baud divider?")
 
     @min_proto_version("0.2")
     @capability('_')
@@ -609,13 +609,13 @@ class ICE(object):
     ## GOC VS EIN HANDLING ##
     def set_goc_ein(self, goc=0, ein=0, restore_clock_freq=True):
         if goc == ein:
-            raise self.ICE_Error, "Internal consistency goc vs ein failure"
+            raise self.ICE_Error("Internal consistency goc vs ein failure")
 
         if self.minor == 1:
             if goc == 1:
                 return
             else:
-                raise self.ICE_Error, "Attempt to call set_goc_ein for ein with protocol version 1"
+                raise self.ICE_Error("Attempt to call set_goc_ein for ein with protocol version 1")
 
         if ein:
             # Set to EIN mode
@@ -656,7 +656,7 @@ class ICE(object):
     def goc_ein_get_freq_divisor_max_0_2(self):
         resp = self.send_message_until_acked('O', struct.pack("B", ord('c')))
         if len(resp) != 3:
-            raise self.FormatError, "Wrong response length from `Oc': " + str(resp)
+            raise self.FormatError("Wrong response length from `Oc': " + str(resp))
         setting = struct.unpack("!I", "\x00"+resp)[0]
         return setting
 
@@ -664,7 +664,7 @@ class ICE(object):
     def goc_ein_get_freq_divisor_min_0_3(self):
         resp = self.send_message_until_acked('O', struct.pack("B", ord('c')))
         if len(resp) != 4:
-            raise self.FormatError, "Wrong response length from `Oc': " + str(resp)
+            raise self.FormatError("Wrong response length from `Oc': " + str(resp))
         setting = struct.unpack("!I", resp)[0]
         logger.debug('got divisor value {}'.format(setting))
         return setting
@@ -679,7 +679,7 @@ class ICE(object):
     def goc_ein_set_freq_divisor_max_0_2(self, divisor):
         packed = struct.pack("!I", divisor)
         if packed[0] != '\x00':
-            raise self.ParameterError, "Out of range."
+            raise self.ParameterError("Out of range.")
         msg = struct.pack("B", ord('c')) + packed[1:]
         self.send_message_until_acked('o', msg)
 
@@ -802,7 +802,7 @@ class ICE(object):
         self.min_version(0.2)
         resp = self.send_message_until_acked('O', struct.pack("B", ord('o')))
         if len(resp) != 1:
-            raise self.FormatError, "Wrong response length from `Oo': " + str(resp)
+            raise self.FormatError("Wrong response length from `Oo': " + str(resp))
         onoff = struct.unpack("B", resp)[0]
         return bool(onoff)
 
@@ -862,7 +862,7 @@ class ICE(object):
             # XXX Generalize me w.r.t. version?
             return 100
         else:
-            raise self.ICE_Error, "Unknown Error"
+            raise self.ICE_Error("Unknown Error")
 
     @min_proto_version("0.1")
     @capability('i')
@@ -893,9 +893,9 @@ class ICE(object):
         ret = ord(msg[0])
         msg = msg[1:]
         if ret == errno.EINVAL:
-            raise self.ICE_Error, "ICE reports: Invalid argument."
+            raise self.ICE_Error("ICE reports: Invalid argument.")
         elif ret == errno.ENODEV:
-            raise self.ICE_Error, "Changing I2C speed not supported."
+            raise self.ICE_Error("Changing I2C speed not supported.")
 
     @min_proto_version("0.1")
     @capability('I')
@@ -905,7 +905,7 @@ class ICE(object):
         '''
         resp = self.send_message_until_acked('I', struct.pack("B", ord('a')))
         if len(resp) != 2:
-            raise self.FormatError, "i2c address response should be 2 bytes"
+            raise self.FormatError("i2c address response should be 2 bytes")
         ones, zeros = struct.unpack("BB", resp)
         if ones == 0xff and zeros == 0xff:
             return None
@@ -933,7 +933,7 @@ class ICE(object):
             ones, zeros = (0xff, 0xff)
         else:
             if len(address) != 8:
-                raise self.FormatError, "Address must be exactly 8 bits"
+                raise self.FormatError("Address must be exactly 8 bits")
             ones, zeros = self.string_to_masks(address)
         self.send_message_until_acked('i', struct.pack("BBB", ord('a'), ones, zeros))
 
@@ -960,7 +960,7 @@ class ICE(object):
         '''
         self.min_version(0.2)
         if len(addr) > 4:
-            raise self.FormatError, "Address too long"
+            raise self.FormatError("Address too long")
         while len(addr) < 4:
             addr = '\x00' + addr
         msg = addr + data
@@ -986,7 +986,7 @@ class ICE(object):
             ones, zeros = (0xfffff, 0xfffff)
         else:
             if len(prefix) != 20:
-                raise self.FormatError, "Prefix must be exactly 20 bits"
+                raise self.FormatError("Prefix must be exactly 20 bits")
             ones, zeros = self.string_to_masks(prefix)
         ones <<= 4
         zeros <<= 4
@@ -1009,7 +1009,7 @@ class ICE(object):
         self.min_version(0.2)
         resp = self.send_message_until_acked('M', struct.pack("B", ord('l')))
         if len(resp) != 6:
-            raise self.FormatError, "Full prefix response should be 6 bytes"
+            raise self.FormatError("Full prefix response should be 6 bytes")
         o_hig, o_mid, o_low, z_hig, z_mid, z_low = struct.unpack("BBBBBB", resp)
         ones = o_low | o_mid << 8 | o_hig << 16
         zeros = z_low | z_mid << 8 | z_hig << 16
@@ -1033,7 +1033,7 @@ class ICE(object):
             ones, zeros = (0xf, 0xf)
         else:
             if len(prefix) != 4:
-                raise self.FormatError, "Prefix must be exactly 4 bits"
+                raise self.FormatError("Prefix must be exactly 4 bits")
             ones, zeros = self.string_to_masks(prefix)
         ones <<= 4
         zeros <<= 4
@@ -1052,7 +1052,7 @@ class ICE(object):
         self.min_version(0.2)
         resp = self.send_message_until_acked('M', struct.pack("B", ord('s')))
         if len(resp) != 2:
-            raise self.FormatError, "Full prefix response should be 2 bytes"
+            raise self.FormatError("Full prefix response should be 2 bytes")
         ones, zeros = struct.unpack("BB", resp)
         ones >>= 4
         zeros >>= 4
@@ -1081,7 +1081,7 @@ class ICE(object):
             ones, zeros = (0xfffff, 0xfffff)
         else:
             if len(prefix) != 20:
-                raise self.FormatError, "Prefix must be exactly 20 bits"
+                raise self.FormatError("Prefix must be exactly 20 bits")
             ones, zeros = self.string_to_masks(prefix)
         ones <<= 4
         zeros <<= 4
@@ -1104,7 +1104,7 @@ class ICE(object):
         self.min_version(0.2)
         resp = self.send_message_until_acked('M', struct.pack("B", ord('L')))
         if len(resp) != 6:
-            raise self.FormatError, "Full prefix response should be 6 bytes"
+            raise self.FormatError("Full prefix response should be 6 bytes")
         o_hig, o_mid, o_low, z_hig, z_mid, z_low = struct.unpack("BBBBBB", resp)
         ones = o_low | o_mid << 8 | o_hig << 16
         zeros = z_low | z_mid << 8 | z_hig << 16
@@ -1128,7 +1128,7 @@ class ICE(object):
             ones, zeros = (0xf, 0xf)
         else:
             if len(prefix) != 4:
-                raise self.FormatError, "Prefix must be exactly 4 bits"
+                raise self.FormatError("Prefix must be exactly 4 bits")
             ones, zeros = self.string_to_masks(prefix)
         ones <<= 4
         zeros <<= 4
@@ -1147,7 +1147,7 @@ class ICE(object):
         self.min_version(0.2)
         resp = self.send_message_until_acked('M', struct.pack("B", ord('S')))
         if len(resp) != 2:
-            raise self.FormatError, "Full prefix response should be 2 bytes"
+            raise self.FormatError("Full prefix response should be 2 bytes")
         ones, zeros = struct.unpack("BB", resp)
         ones >>= 4
         zeros >>= 4
@@ -1176,7 +1176,7 @@ class ICE(object):
             ones, zeros = (0xf, 0xf)
         else:
             if len(mask) != 4:
-                raise self.FormatError, "Prefix must be exactly 4 bits"
+                raise self.FormatError("Prefix must be exactly 4 bits")
             ones, zeros = self.string_to_masks(mask)
         self.send_message_until_acked('m', struct.pack("B"*(1+2),
             ord('b'),
@@ -1193,7 +1193,7 @@ class ICE(object):
         self.min_version(0.2)
         resp = self.send_message_until_acked('M', struct.pack("B", ord('b')))
         if len(resp) != 2:
-            raise self.FormatError, "Broadcast mask response should be 2 bytes"
+            raise self.FormatError("Broadcast mask response should be 2 bytes")
         ones, zeros = struct.unpack("BB", resp)
         if ones == 0xf and zeros == 0xf:
             return None
@@ -1220,7 +1220,7 @@ class ICE(object):
             ones, zeros = (0xf, 0xf)
         else:
             if len(mask) != 4:
-                raise self.FormatError, "Prefix must be exactly 4 bits"
+                raise self.FormatError("Prefix must be exactly 4 bits")
             ones, zeros = self.string_to_masks(mask)
         self.send_message_until_acked('m', struct.pack("B"*(1+2),
             ord('B'),
@@ -1237,7 +1237,7 @@ class ICE(object):
         self.min_version(0.2)
         resp = self.send_message_until_acked('M', struct.pack("B", ord('B')))
         if len(resp) != 2:
-            raise self.FormatError, "Broadcast mask response should be 2 bytes"
+            raise self.FormatError("Broadcast mask response should be 2 bytes")
         ones, zeros = struct.unpack("BB", resp)
         if ones == 0xf and zeros == 0xf:
             return None
@@ -1253,7 +1253,7 @@ class ICE(object):
         self.min_version(0.2)
         resp = self.send_message_until_acked('M', struct.pack("B", ord('m')))
         if len(resp) != 1:
-            raise self.FormatError, "Wrong response length from `Mm': " + str(resp)
+            raise self.FormatError("Wrong response length from `Mm': " + str(resp))
         onoff = struct.unpack("B", resp)[0]
         return bool(onoff)
 
@@ -1420,7 +1420,7 @@ class ICE(object):
         Setup a GPIO pin.
         '''
         if direction not in (ICE.GPIO_INPUT, ICE.GPIO_OUTPUT, ICE.GPIO_TRISTATE):
-            raise self.ParameterError, "Unknown direction: " + str(direction)
+            raise self.ParameterError("Unknown direction: " + str(direction))
         if self.minor == 1:
             return self.gpio_set_direction_0_1(gpio_idx, direction)
         else:
@@ -1433,7 +1433,7 @@ class ICE(object):
         resp = self.send_message_until_acked('G',
                 struct.pack('BB', ord('l'), gpio_idx))
         if len(resp) != 1:
-            raise self.FormatError, "Too long of a response from `Gl#':" + str(resp)
+            raise self.FormatError("Too long of a response from `Gl#':" + str(resp))
 
         return bool(struct.unpack("B", resp)[0])
 
@@ -1444,11 +1444,11 @@ class ICE(object):
         resp = self.send_message_until_acked('G',
                 struct.pack('BB', ord('d'), gpio_idx))
         if len(resp) != 1:
-            raise self.FormatError, "Too long of a response from `Gd#':" + str(resp)
+            raise self.FormatError("Too long of a response from `Gd#':" + str(resp))
 
         direction = struct.unpack("B", resp)[0]
         if direction not in (ICE.GPIO_INPUT, ICE.GPIO_OUTPUT, ICE.GPIO_TRISTATE):
-            raise self.FormatError, "Unknown direction: " + str(direction)
+            raise self.FormatError("Unknown direction: " + str(direction))
 
         return direction
 
@@ -1469,29 +1469,29 @@ class ICE(object):
     def _gpio_get_level_0_2(self):
         resp = self.send_message_until_acked('G', struct.pack('B', ord('l')))
         if len(resp) != 3:
-            raise self.FormatError, "Bad response from `Gl':" + str(resp)
-        high,mid,low = map(ord, resp)
+            raise self.FormatError("Bad response from `Gl':" + str(resp))
+        high,mid,low = list(map(ord, resp))
         return low | (mid << 8) | (high << 16)
 
     @min_proto_version("0.2")
     @capability('G')
     def gpio_get_level_0_2(self, gpio_idx):
         if gpio_idx >= 24:
-            raise self.ParameterError, "Request for illegal gpio idx"
+            raise self.ParameterError("Request for illegal gpio idx")
         return (self._gpio_get_level_0_2() >> gpio_idx) & 0x1
 
     def _gpio_get_direction_0_2(self):
         resp = self.send_message_until_acked('G', struct.pack('B', ord('d')))
         if len(resp) != 3:
-            raise self.FormatError, "Bad response from `Gd#':" + str(resp)
-        high,mid,low = map(ord, resp)
+            raise self.FormatError("Bad response from `Gd#':" + str(resp))
+        high,mid,low = list(map(ord, resp))
         return low | (mid << 8) | (high << 16)
 
     @min_proto_version("0.2")
     @capability('G')
     def gpio_get_direction_0_2(self, gpio_idx):
         if gpio_idx >= 24:
-            raise self.ParameterError, "Request for illegal gpio idx"
+            raise self.ParameterError("Request for illegal gpio idx")
 
         if ((self._gpio_get_direction_0_2() >> gpio_idx) & 0x1) == 0:
             return ICE.GPIO_INPUT
@@ -1521,7 +1521,7 @@ class ICE(object):
         elif direction in (ICE.GPIO_INPUT, ICE.GPIO_TRISTATE):
             mask &= ~(1 << gpio_idx)
         else:
-            raise self.ParameterError, "Illegal GPIO direction"
+            raise self.ParameterError("Illegal GPIO direction")
         self.send_message_until_acked('g',
                 struct.pack('BBBB', ord('d'),
                     (mask >> 16) & 0xff,
@@ -1533,8 +1533,8 @@ class ICE(object):
     def gpio_get_interrupt_enable_mask(self):
         resp = self.send_message_until_acked('G', struct.pack('B', ord('i')))
         if len(resp) != 3:
-            raise self.FormatError, "Bad response from `Gi':" + str(resp)
-        high,mid,low = map(ord, resp)
+            raise self.FormatError("Bad response from `Gi':" + str(resp))
+        high,mid,low = list(map(ord, resp))
         return low | (mid << 8) | (high << 16)
 
     @min_proto_version("0.2")
@@ -1568,7 +1568,7 @@ class ICE(object):
             ICE.POWER_VBATT
         '''
         if rail not in (ICE.POWER_0P6, ICE.POWER_1P2, ICE.POWER_VBATT):
-            raise self.ParameterError, "Invalid rail: " + str(rail)
+            raise self.ParameterError("Invalid rail: " + str(rail))
 
         logger.warn("ICE Firmware <= 0.3 cannot query voltage. Returning cached value.")
         try:
@@ -1597,11 +1597,11 @@ class ICE(object):
         Returns a boolean, on=True.
         '''
         if rail not in (ICE.POWER_0P6, ICE.POWER_1P2, ICE.POWER_VBATT, ICE.POWER_GOC):
-            raise self.ParameterError, "Invalid rail: " + str(rail)
+            raise self.ParameterError("Invalid rail: " + str(rail))
 
         resp = self.send_message_until_acked('P', struct.pack("BB", ord('o'), rail))
         if len(resp) != 1:
-            raise self.FormatError, "Too long of a response from `Po#':" + str(resp)
+            raise self.FormatError("Too long of a response from `Po#':" + str(resp))
         onoff = struct.unpack("B", resp)[0]
         return bool(onoff)
 
@@ -1612,7 +1612,7 @@ class ICE(object):
         Set the voltage setting of a power rail. Units are V.
         '''
         if rail not in (ICE.POWER_0P6, ICE.POWER_1P2, ICE.POWER_VBATT):
-            raise self.ParameterError, "Invalid rail: " + str(rail)
+            raise self.ParameterError("Invalid rail: " + str(rail))
 
         # Vout = (0.537 + 0.0185 * v_set) * Vdefault
         output_voltage = float(output_voltage)
@@ -1621,7 +1621,7 @@ class ICE(object):
         vset = ((output_voltage / default_voltage) - 0.537) / 0.0185
         vset = int(vset)
         if (vset < 0) or (vset > 255):
-            raise self.ParameterError, "Voltage exceeds range. vset: " + str(vset)
+            raise self.ParameterError("Voltage exceeds range. vset: " + str(vset))
 
         self.send_message_until_acked('p', struct.pack("BBB", ord('v'), rail, vset))
         setattr(self, 'power_{}'.format(rail), vset)
@@ -1633,7 +1633,7 @@ class ICE(object):
         Turn a power rail on or off (on=True).
         '''
         if rail not in (ICE.POWER_0P6, ICE.POWER_1P2, ICE.POWER_VBATT, ICE.POWER_GOC):
-            raise self.ParameterError, "Invalid rail: " + str(rail)
+            raise self.ParameterError("Invalid rail: " + str(rail))
 
         self.send_message_until_acked('p', struct.pack("BBB", ord('o'), rail, onoff))
 

--- a/platforms/HT_m3/programming/listen.py
+++ b/platforms/HT_m3/programming/listen.py
@@ -4,7 +4,7 @@ from time import sleep
 import socket
 import sys
 import os
-import Queue
+import queue
 import logging
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger('program')
@@ -35,7 +35,7 @@ ice.msg_handler['d+'] = async_helper
 ice.connect(sys.argv[1])
 ice.i2c_set_address("1001100x") # 0x98
 
-resp = raw_input("Would you like to send the DMA start interrupt? [Y/n] ")
+resp = input("Would you like to send the DMA start interrupt? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     sys.exit()
 
@@ -43,4 +43,4 @@ logger.info("Sending 0x88 0x00000000")
 ice.i2c_send(0x88, "00000000".decode('hex'))
 
 logger.info("Listening...")
-resp = raw_input("Press enter at any time to quit\n")
+resp = input("Press enter at any time to quit\n")

--- a/platforms/HT_m3/programming/m3_common.py
+++ b/platforms/HT_m3/programming/m3_common.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import socket
-from Queue import Queue
+from queue import Queue
 import argparse
 import time
 
@@ -35,11 +35,11 @@ class m3_common(object):
     @staticmethod
     def default_value(prompt, default, extra=None, invert=False):
         if invert and (extra is None):
-            raise RuntimeError, "invert & !extra ?"
+            raise RuntimeError("invert & !extra ?")
         if extra:
-            r = raw_input(prompt + ' [' + default + extra + ']: ')
+            r = input(prompt + ' [' + default + extra + ']: ')
         else:
-            r = raw_input(prompt + ' [' + default + ']: ')
+            r = input(prompt + ' [' + default + ']: ')
         if len(r) == 0:
             if invert:
                 return extra
@@ -100,7 +100,7 @@ class m3_common(object):
 
         # Byte 8: bit-wise XOR parity of data
         data_parity = 0
-        for byte in [hexencoded[x:x+2] for x in xrange(0, len(hexencoded), 2)]:
+        for byte in [hexencoded[x:x+2] for x in range(0, len(hexencoded), 2)]:
             b = int(byte, 16)
             data_parity ^= b
 
@@ -192,10 +192,10 @@ class m3_common(object):
         else:
             def pick_serial():
                 logger.info("Multiple possible serial ports found:")
-                for i in xrange(len(candidates)):
+                for i in range(len(candidates)):
                     logger.info("\t[{}] {}".format(i, candidates[i]))
                 try:
-                    resp = raw_input("Choose a serial port (Ctrl-C to quit): ").strip()
+                    resp = input("Choose a serial port (Ctrl-C to quit): ").strip()
                 except KeyboardInterrupt:
                     sys.exit(1)
                 try:

--- a/platforms/HT_m3/programming/program_via_i2c.py
+++ b/platforms/HT_m3/programming/program_via_i2c.py
@@ -8,7 +8,7 @@ import socket
 import sys
 import os
 import mimetypes
-import Queue
+import queue
 import logging
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger('program')
@@ -77,7 +77,7 @@ def validate_bin_helper(msg_type, event_id, length, msg):
         return
     validate_q.put(msg)
 
-validate_q = Queue.Queue()
+validate_q = queue.Queue()
 ice.msg_handler['d+'] = validate_bin_helper
 
 ice.connect(sys.argv[2])
@@ -106,7 +106,7 @@ logger.info("M3 0.6V => ON")
 ice.power_set_onoff(0,True)
 sleep(4.0)
 
-resp = raw_input("About to send I2C message to wake controller. Continue? [Y/n] ")
+resp = input("About to send I2C message to wake controller. Continue? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     sys.exit()
 
@@ -183,7 +183,7 @@ def validate_bin(ice, hexencoded, offset=0):
     logger.info("Programming validated successfully")
     return True
 
-resp = raw_input("About to send program data to I2C. Continue? [Y/n] ")
+resp = input("About to send program data to I2C. Continue? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     sys.exit()
 
@@ -214,7 +214,7 @@ logger.info('=' * 80)
 logger.info("Programming complete.")
 logger.info("")
 
-resp = raw_input("Would you like to send the DMA start interrupt? [Y/n] ")
+resp = input("Would you like to send the DMA start interrupt? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     sys.exit()
 

--- a/platforms/m3/programming/ein.py
+++ b/platforms/m3/programming/ein.py
@@ -2,7 +2,7 @@
 
 import sys, socket
 import time
-import Queue
+#import queue
 import logging
 
 from m3_common import m3_common
@@ -23,7 +23,7 @@ class ein_programmer(m3_common):
 
 # Callback for async MBus message
 #ice.msg_handler['b+'] = validate_bin_helper
-#validate_q = Queue.Queue()
+#validate_q = queue.queue()
 def validate_bin_helper(msg_type, event_id, length, msg):
     logger.debug("Bin Helper got msg len" + str(len(msg)))
     if len(msg) == 0:

--- a/platforms/m3/programming/fake_ice.py
+++ b/platforms/m3/programming/fake_ice.py
@@ -113,7 +113,7 @@ except:
     raise
 if not s.isOpen():
     logger.error('Could not open serial port at: ' + serial_port)
-    raise IOError, "Failed to open serial port"
+    raise IOError("Failed to open serial port")
 
 class Gpio(object):
     GPIO_INPUT    = 0
@@ -134,7 +134,7 @@ class Gpio(object):
         elif self.direction == Gpio.GPIO_TRISTATE:
             s += 'TRI'
         else:
-            raise RuntimeError, "wtf"
+            raise RuntimeError("wtf")
 
         s += ' - '
 
@@ -154,17 +154,17 @@ class Gpio(object):
     def __setattr__(self, name, value):
         if name is 'direction':
             if value not in (Gpio.GPIO_INPUT, Gpio.GPIO_OUTPUT, Gpio.GPIO_TRISTATE):
-                raise ValueError, "Attempt to set illegal direction", value
+                raise ValueError("Attempt to set illegal direction {}".format(value))
         if name is 'level':
             if value not in (True, False):
-                raise ValueError, "GPIO level must be true or false. Got", value
+                raise ValueError("GPIO level must be true or false. Got {}".format(value))
         if name is 'interrupt':
             if value not in (True, False):
-                raise ValueError, "GPIO interrupt must be true or false. Got", value
+                raise ValueError("GPIO interrupt must be true or false. Got {}".format(value))
         object.__setattr__(self, name, value)
 
 event = 0
-gpios = [Gpio() for x in xrange(MAX_GPIO)]
+gpios = [Gpio() for x in range(MAX_GPIO)]
 
 def spurious_message_thread():
     global s
@@ -257,7 +257,7 @@ def replay_message_thread():
         last_ts = ts
 
         print(data)
-        print(len(data)/2.0)
+        print((len(data)/2.0))
         send_snoop(addr, data, '02')
 
     logger.info("Replay finished.")
@@ -461,19 +461,19 @@ while True:
             else:
                 if msg[0] == 'l':
                     mask = 0
-                    for i in xrange(len(gpios)):
+                    for i in range(len(gpios)):
                         mask |= (gpios[i].level << i)
                     logger.info("Responded to request for GPIO level mask (%06x)", mask)
                     respond(chr((mask >> 16) & 0xff) + chr((mask >> 8) & 0xff) + chr(mask >> 8))
                 elif msg[0] == 'd':
                     mask = 0
-                    for i in xrange(len(gpios)):
+                    for i in range(len(gpios)):
                         mask |= (gpios[i].direction << i)
                     logger.info("Responded to request for GPIO direction mask (%06x)", mask)
                     respond(chr((mask >> 16) & 0xff) + chr((mask >> 8) & 0xff) + chr(mask >> 8))
                 elif msg[0] == 'i':
                     mask = 0
-                    for i in xrange(len(gpios)):
+                    for i in range(len(gpios)):
                         mask |= (gpios[i].interrupt << i)
                     logger.info("Responded to request for GPIO interrupt mask (%06x)", mask)
                     respond(chr((mask >> 16) & 0xff) + chr((mask >> 8) & 0xff) + chr(mask >> 8))
@@ -496,23 +496,23 @@ while True:
                     raise Exception
             else:
                 if msg[0] == 'l':
-                    high,mid,low = map(ord, msg[1:])
+                    high,mid,low = list(map(ord, msg[1:]))
                     mask = low | mid << 8 | high << 16
-                    for i in xrange(24):
+                    for i in range(24):
                         gpios[i].level = (mask >> i) & 0x1
                     logger.info("Set GPIO level mask to: %06x", mask)
                     ack()
                 elif msg[0] == 'd':
-                    high,mid,low = map(ord, msg[1:])
+                    high,mid,low = list(map(ord, msg[1:]))
                     mask = low | mid << 8 | high << 16
-                    for i in xrange(24):
+                    for i in range(24):
                         gpios[i].direction = (mask >> i) & 0x1
                     logger.info("Set GPIO direction mask to: %06x", mask)
                     ack()
                 elif msg[0] == 'i':
-                    high,mid,low = map(ord, msg[1:])
+                    high,mid,low = list(map(ord, msg[1:]))
                     mask = low | mid << 8 | high << 16
-                    for i in xrange(24):
+                    for i in range(24):
                         gpios[i].interrupt = (mask >> i) & 0x1
                     logger.info("Set GPIO interrupt mask to: %06x", mask)
                     ack()
@@ -577,7 +577,7 @@ while True:
                         ("off", "on")[mbus_ismaster])
                 respond(chr(mbus_ismaster))
             elif msg[0] == 'c':
-                raise NotImplementedError, "MBus clock not defined"
+                raise NotImplementedError("MBus clock not defined")
             elif msg[0] == 'i':
                 logger.info("Responded to query for MBus should interrupt (%d)",
                         mbus_should_interrupt)
@@ -631,7 +631,7 @@ while True:
                 logger.info("MBus master mode set " + ("off", "on")[mbus_ismaster])
                 ack()
             elif msg[0] == 'c':
-                raise NotImplementedError, "MBus clock not defined"
+                raise NotImplementedError("MBus clock not defined")
             elif msg[0] == 'i':
                 mbus_should_interrupt = ord(msg[1])
                 logger.info("MBus should interrupt set to %d", mbus_should_interrupt)

--- a/platforms/m3/programming/goc.py
+++ b/platforms/m3/programming/goc.py
@@ -41,7 +41,7 @@ logger.info("Would you like to run after programming? If you do not")
 logger.info("have GOC start the program, you will be prompted to send")
 logger.info("the start message via DMA at the end instead")
 logger.info("")
-resp = raw_input("Run program when GOC finishes? [Y/n] ")
+resp = input("Run program when GOC finishes? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     run_after = 0
 else:

--- a/platforms/m3/programming/goc_gdp_test.py
+++ b/platforms/m3/programming/goc_gdp_test.py
@@ -19,7 +19,7 @@ gcl_handle = gdp.GDP_GCL(gcl_name, gdp.GDP_MODE_RA)
 
 while True:
 	try:
-		idx = int(raw_input("Image index: "))
+		idx = int(input("Image index: "))
 
 		record = gcl_handle.read(idx)
 		raw = record['data']

--- a/platforms/m3/programming/goc_to_image.py
+++ b/platforms/m3/programming/goc_to_image.py
@@ -9,7 +9,7 @@ import sys
 import time
 
 import threading
-import Queue
+import queue
 
 import numpy as np
 
@@ -102,7 +102,7 @@ BLUE  = pygame.Color(  0,   0, 255)
 WHITE = pygame.Color(255, 255, 255)
 BLACK = pygame.Color(  0,   0,   0)
 
-colors = [pygame.Color(x,x,x) for x in xrange(256)]
+colors = [pygame.Color(x,x,x) for x in range(256)]
 colors.insert(0, RED)
 
 # http://stackoverflow.com/questions/17202232/even-with-pygame-initialized-video-system-not-initialized-gets-thrown
@@ -166,7 +166,7 @@ def get_addr17_msg_file():
     for line in open(args.file):
         line = line.strip()
         if searching:
-            if line in map(lambda a: 'Address {:x}'.format(a), args.address):
+            if line in ['Address {:x}'.format(a) for a in args.address]:
                 searching = False
             continue
         if line.split()[0] == 'Data':
@@ -174,10 +174,10 @@ def get_addr17_msg_file():
             continue
         yield data
         data = []
-        if line not in map(lambda a: 'Address {:x}'.format(a), args.address):
+        if line not in ['Address {:x}'.format(a) for a in args.address]:
             searching = True
 
-serial_queue = Queue.Queue()
+serial_queue = queue.Queue()
 def get_addr17_msg_serial():
     while True:
         addr, data = serial_queue.get()
@@ -228,45 +228,45 @@ def get_image_g(data_generator):
         end_of_image = False
 
         # Grab an image
-        for row in xrange(args.pixels):
-            r = data_generator.next()
+        for row in range(args.pixels):
+            r = next(data_generator)
             while is_motion_detect_msg(r):
-                print "Skipping motion detect message"
-                r = data_generator.next()
+                print("Skipping motion detect message")
+                r = next(data_generator)
             if is_end_of_image_msg(r):
-                print "Unexpected end-of-image. Expecting row", row + 1
-                print "Returning partial image"
+                print("Unexpected end-of-image. Expecting row", row + 1)
+                print("Returning partial image")
                 end_of_image = True
                 break
             if len(r) != args.pixels:
-                print "Row %d message incorrect length: %d" % (row, len(r))
-                print "Using first %d pixel(s)" % (min(len(r), args.pixels))
-            for p in xrange(min(len(r), args.pixels)):
+                print("Row %d message incorrect length: %d" % (row, len(r)))
+                print("Using first %d pixel(s)" % (min(len(r), args.pixels)))
+            for p in range(min(len(r), args.pixels)):
                 data[row][p] = r[p] + 1
 
         while not end_of_image:
-            m = data_generator.next()
+            m = next(data_generator)
             if is_end_of_image_msg(m):
                 break
-            print "Expected end-of-image. Got message of length:", len(m)
+            print("Expected end-of-image. Got message of length:", len(m))
 
             # If imager sends more rows than expected, discard this earliest
             # received rows. Works around wakeup bug.
             data = np.roll(data, -1, axis=0)
-            for p in xrange(min(len(m), args.pixels)):
+            for p in range(min(len(m), args.pixels)):
                 data[-1][p] = m[p] + 1
             if len(m) != args.pixels:
-                print "Extra row message incorrect length: %d" % (len(m))
-                print "Zeroing remaining pixels"
-                for p in xrange(len(m), args.pixels):
+                print("Extra row message incorrect length: %d" % (len(m)))
+                print("Zeroing remaining pixels")
+                for p in range(len(m), args.pixels):
                     data[-1][p] = 0
 
         yield data
 
 def correct_endianish_thing_old(data, array):
-    for row in xrange(args.pixels):
-        for colset in xrange(0, args.pixels, 4):
-            for i in xrange(4):
+    for row in range(args.pixels):
+        for colset in range(0, args.pixels, 4):
+            for i in range(4):
                 if rotate_90:
                     val = data[colset+3-i][row]
                 else:
@@ -281,9 +281,9 @@ def correct_endianish_thing_old(data, array):
                 array[row][colset+i] = rgb
 
 def correct_endianish_thing(data, array):
-    for rowbase in xrange(0, args.pixels, 4):
-        for rowi in xrange(4):
-            for col in xrange(0, args.pixels):
+    for rowbase in range(0, args.pixels, 4):
+        for rowi in range(4):
+            for col in range(0, args.pixels):
                 if rotate_90:
                     val = data[col][rowbase + 3-rowi]
                 else:
@@ -302,7 +302,7 @@ def correct_endianish_thing(data, array):
                 array[rowbase+rowi][col] = rgb
 
 
-images_q = Queue.Queue()
+images_q = queue.Queue()
 
 
 def process_hot_pixels(img):
@@ -357,7 +357,7 @@ def get_image_idx(idx):
 			raw,hot = images_q.get_nowait()
 			images_raw.append(raw)
 			images.append(hot)
-		except Queue.Empty:
+		except queue.Empty:
 			break
 	return images[idx]
 
@@ -369,24 +369,24 @@ pygame.event.set_allowed((QUIT, KEYUP, MOUSEBUTTONUP, MOUSEMOTION))
 goc_raw_Surface = pygame.Surface((args.pixels, args.pixels))
 
 def render_raw_goc_data(data):
-    print "Request to render raw goc data"
-    print "Correcting pixel order bug"
+    print("Request to render raw goc data")
+    print("Correcting pixel order bug")
     surface_array = pygame.surfarray.pixels2d(goc_raw_Surface)
     correct_endianish_thing(data, surface_array)
     del surface_array
-    print "Scaling %d pixel --> %d pixel%s" % (1, args.scale, ('s','')[args.scale == 1])
+    print("Scaling %d pixel --> %d pixel%s" % (1, args.scale, ('s','')[args.scale == 1]))
     pygame.transform.scale(goc_raw_Surface, (args.pixels*args.scale, args.pixels*args.scale), gocSurfaceObj)
-    print "Rendering Image"
+    print("Rendering Image")
     pygame.display.update()
-    print
+    print()
 
 def render_image_idx(idx):
-    print "Request to render image", idx
+    print("Request to render image", idx)
     render_raw_goc_data(get_image_idx(idx))
 
 def save_image(filename):
     pygame.image.save(gocSurfaceObj, filename)
-    print 'Image saved to', filename
+    print('Image saved to', filename)
 
 def save_image_hack():
 	imgname = "capture%02d.jpeg" % (current_idx)
@@ -403,7 +403,7 @@ def save_image_hack():
 		raw_csvname = os.path.join(args.output_directory, raw_csvname)
 		raw_ofile = csv.writer(open(raw_csvname, 'w'), dialect='excel')
 		raw_ofile.writerows(images_raw[current_idx])
-	print 'CSV of image saved to', csvname
+	print('CSV of image saved to', csvname)
 options['save'].on_click = save_image_hack
 
 def advance_image():
@@ -414,8 +414,8 @@ def advance_image():
         save_image_hack()
     except IndexError:
         current_idx -= 1
-        print "At last image. Display left at image", current_idx
-        print
+        print("At last image. Display left at image", current_idx)
+        print()
 options['next'].on_click = advance_image
 
 def rewind_image():
@@ -438,12 +438,12 @@ while True:
         quit()
 
     if event.type == MOUSEBUTTONUP:
-        for option in options.values():
+        for option in list(options.values()):
             if option.rect.collidepoint(pygame.mouse.get_pos()):
                 option.onClick()
 
     if event.type == MOUSEMOTION:
-        for option in options.values():
+        for option in list(options.values()):
             if option.rect.collidepoint(pygame.mouse.get_pos()):
                 option.hovered = True
             else:

--- a/platforms/m3/programming/goc_to_image_with_gdp.py
+++ b/platforms/m3/programming/goc_to_image_with_gdp.py
@@ -9,7 +9,7 @@ import sys
 import time
 
 import threading
-import Queue
+import queue
 
 import numpy as np
 
@@ -94,7 +94,7 @@ try:
 except ImportError:
 	from PIL import Image
 
-gdp_image_queue = Queue.Queue()
+gdp_image_queue = queue.Queue()
 def gdp_thread():
 	gdp.gdp_init()
 	print("GDP: connected.")
@@ -106,7 +106,7 @@ def gdp_thread():
 		im = Image.open(im_fname)
 		data = {"data": im.tostring()}
 		gcl_handle.append(data)
-		print("GDP: posted " + im_fname)
+		print(("GDP: posted " + im_fname))
 
 gdp_thread = threading.Thread(target=gdp_thread)
 gdp_thread.daemon = True
@@ -132,7 +132,7 @@ BLUE  = pygame.Color(  0,   0, 255)
 WHITE = pygame.Color(255, 255, 255)
 BLACK = pygame.Color(  0,   0,   0)
 
-colors = [pygame.Color(x,x,x) for x in xrange(256)]
+colors = [pygame.Color(x,x,x) for x in range(256)]
 colors.insert(0, RED)
 
 # http://stackoverflow.com/questions/17202232/even-with-pygame-initialized-video-system-not-initialized-gets-thrown
@@ -196,7 +196,7 @@ def get_addr17_msg_file():
     for line in open(args.file):
         line = line.strip()
         if searching:
-            if line in map(lambda a: 'Address {:x}'.format(a), args.address):
+            if line in ['Address {:x}'.format(a) for a in args.address]:
                 searching = False
             continue
         if line.split()[0] == 'Data':
@@ -204,10 +204,10 @@ def get_addr17_msg_file():
             continue
         yield data
         data = []
-        if line not in map(lambda a: 'Address {:x}'.format(a), args.address):
+        if line not in ['Address {:x}'.format(a) for a in args.address]:
             searching = True
 
-serial_queue = Queue.Queue()
+serial_queue = queue.Queue()
 def get_addr17_msg_serial():
     while True:
         addr, data = serial_queue.get()
@@ -258,45 +258,45 @@ def get_image_g(data_generator):
         end_of_image = False
 
         # Grab an image
-        for row in xrange(args.pixels):
-            r = data_generator.next()
+        for row in range(args.pixels):
+            r = next(data_generator)
             while is_motion_detect_msg(r):
-                print "Skipping motion detect message"
-                r = data_generator.next()
+                print("Skipping motion detect message")
+                r = next(data_generator)
             if is_end_of_image_msg(r):
-                print "Unexpected end-of-image. Expecting row", row + 1
-                print "Returning partial image"
+                print("Unexpected end-of-image. Expecting row", row + 1)
+                print("Returning partial image")
                 end_of_image = True
                 break
             if len(r) != args.pixels:
-                print "Row %d message incorrect length: %d" % (row, len(r))
-                print "Using first %d pixel(s)" % (min(len(r), args.pixels))
-            for p in xrange(min(len(r), args.pixels)):
+                print("Row %d message incorrect length: %d" % (row, len(r)))
+                print("Using first %d pixel(s)" % (min(len(r), args.pixels)))
+            for p in range(min(len(r), args.pixels)):
                 data[row][p] = r[p] + 1
 
         while not end_of_image:
-            m = data_generator.next()
+            m = next(data_generator)
             if is_end_of_image_msg(m):
                 break
-            print "Expected end-of-image. Got message of length:", len(m)
+            print("Expected end-of-image. Got message of length:", len(m))
 
             # If imager sends more rows than expected, discard this earliest
             # received rows. Works around wakeup bug.
             data = np.roll(data, -1, axis=0)
-            for p in xrange(min(len(m), args.pixels)):
+            for p in range(min(len(m), args.pixels)):
                 data[-1][p] = m[p] + 1
             if len(m) != args.pixels:
-                print "Extra row message incorrect length: %d" % (len(m))
-                print "Zeroing remaining pixels"
-                for p in xrange(len(m), args.pixels):
+                print("Extra row message incorrect length: %d" % (len(m)))
+                print("Zeroing remaining pixels")
+                for p in range(len(m), args.pixels):
                     data[-1][p] = 0
 
         yield data
 
 def correct_endianish_thing_old(data, array):
-    for row in xrange(args.pixels):
-        for colset in xrange(0, args.pixels, 4):
-            for i in xrange(4):
+    for row in range(args.pixels):
+        for colset in range(0, args.pixels, 4):
+            for i in range(4):
                 if rotate_90:
                     val = data[colset+3-i][row]
                 else:
@@ -311,9 +311,9 @@ def correct_endianish_thing_old(data, array):
                 array[row][colset+i] = rgb
 
 def correct_endianish_thing(data, array):
-    for rowbase in xrange(0, args.pixels, 4):
-        for rowi in xrange(4):
-            for col in xrange(0, args.pixels):
+    for rowbase in range(0, args.pixels, 4):
+        for rowi in range(4):
+            for col in range(0, args.pixels):
                 if rotate_90:
                     val = data[col][rowbase + 3-rowi]
                 else:
@@ -332,7 +332,7 @@ def correct_endianish_thing(data, array):
                 array[rowbase+rowi][col] = rgb
 
 
-images_q = Queue.Queue()
+images_q = queue.Queue()
 
 
 def process_hot_pixels(img):
@@ -387,7 +387,7 @@ def get_image_idx(idx):
 			raw,hot = images_q.get_nowait()
 			images_raw.append(raw)
 			images.append(hot)
-		except Queue.Empty:
+		except queue.Empty:
 			break
 	return images[idx]
 
@@ -399,24 +399,24 @@ pygame.event.set_allowed((QUIT, KEYUP, MOUSEBUTTONUP, MOUSEMOTION))
 goc_raw_Surface = pygame.Surface((args.pixels, args.pixels))
 
 def render_raw_goc_data(data):
-    print "Request to render raw goc data"
-    print "Correcting pixel order bug"
+    print("Request to render raw goc data")
+    print("Correcting pixel order bug")
     surface_array = pygame.surfarray.pixels2d(goc_raw_Surface)
     correct_endianish_thing(data, surface_array)
     del surface_array
-    print "Scaling %d pixel --> %d pixel%s" % (1, args.scale, ('s','')[args.scale == 1])
+    print("Scaling %d pixel --> %d pixel%s" % (1, args.scale, ('s','')[args.scale == 1]))
     pygame.transform.scale(goc_raw_Surface, (args.pixels*args.scale, args.pixels*args.scale), gocSurfaceObj)
-    print "Rendering Image"
+    print("Rendering Image")
     pygame.display.update()
-    print
+    print()
 
 def render_image_idx(idx):
-    print "Request to render image", idx
+    print("Request to render image", idx)
     render_raw_goc_data(get_image_idx(idx))
 
 def save_image(filename):
     pygame.image.save(gocSurfaceObj, filename)
-    print 'Image saved to', filename
+    print('Image saved to', filename)
     gdp_image_queue.put(filename)
 
 def save_image_hack():
@@ -434,7 +434,7 @@ def save_image_hack():
 		raw_csvname = os.path.join(args.output_directory, raw_csvname)
 		raw_ofile = csv.writer(open(raw_csvname, 'w'), dialect='excel')
 		raw_ofile.writerows(images_raw[current_idx])
-	print 'CSV of image saved to', csvname
+	print('CSV of image saved to', csvname)
 options['save'].on_click = save_image_hack
 
 def advance_image():
@@ -445,8 +445,8 @@ def advance_image():
         save_image_hack()
     except IndexError:
         current_idx -= 1
-        print "At last image. Display left at image", current_idx
-        print
+        print("At last image. Display left at image", current_idx)
+        print()
 options['next'].on_click = advance_image
 
 def rewind_image():
@@ -469,12 +469,12 @@ while True:
         quit()
 
     if event.type == MOUSEBUTTONUP:
-        for option in options.values():
+        for option in list(options.values()):
             if option.rect.collidepoint(pygame.mouse.get_pos()):
                 option.onClick()
 
     if event.type == MOUSEMOTION:
-        for option in options.values():
+        for option in list(options.values()):
             if option.rect.collidepoint(pygame.mouse.get_pos()):
                 option.hovered = True
             else:

--- a/platforms/m3/programming/goc_v2.py
+++ b/platforms/m3/programming/goc_v2.py
@@ -52,7 +52,7 @@ logger.info("Would you like to run after programming? If you do not")
 logger.info("have GOC start the program, you will be prompted to send")
 logger.info("the start message via DMA at the end instead")
 logger.info("")
-resp = raw_input("Run program when GOC finishes? [Y/n] ")
+resp = input("Run program when GOC finishes? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     run_after = 0
 else:

--- a/platforms/m3/programming/gui.py
+++ b/platforms/m3/programming/gui.py
@@ -8,12 +8,12 @@ import logging
 import inspect
 from datetime import datetime
 import glob
-import ConfigParser
-import Queue
+import configparser
+import queue
 import argparse
-import Tkinter as Tk
-import ttk
-import tkFileDialog, tkMessageBox
+import tkinter as Tk
+import tkinter.ttk
+import tkinter.filedialog, tkinter.messagebox
 from idlelib.WidgetRedirector import WidgetRedirector
 
 from m3 import m3_logging
@@ -74,12 +74,12 @@ def report_event(event):
 			"2": "KeyPress",
 			"4": "ButtonPress",
 			}
-	print("EventTime={}".format(event.time),
+	print(("EventTime={}".format(event.time),
 			"EventType={}".format(event.type),
 			event_name[str(event.type)],
 			"EventWidgetId={}".format(event.widget),
 			"EventKeySymbol={}".format(event.keysym)
-			)
+			))
 
 def add_returns(widget, callback):
 	widget.bind("<Return>", event_lambda(callback))
@@ -124,11 +124,11 @@ def make_modal(window, parent):
 	window.grab_set()
 	parent.wait_window(window)
 
-class ButtonWithReturns(ttk.Button):
+class ButtonWithReturns(tkinter.ttk.Button):
 	# n.b.: ttk.Button is an old-style class
 	def __init__(self, *args, **kwargs):
 		#logger.trace('ButtonWithReturns self {}'.format(repr(self)))
-		ttk.Button.__init__(self, *args, **kwargs)
+		tkinter.ttk.Button.__init__(self, *args, **kwargs)
 		try:
 			add_returns(self, kwargs['command'])
 		except KeyError:
@@ -156,7 +156,7 @@ def async_call(parent, fn, timeout_in_ms=500, cancellable=False):
 			ret = fn()
 			comp_queue.put(True)
 			comp_queue.put(ret)
-		except Exception, e:
+		except Exception as e:
 			comp_queue.put(False)
 			comp_queue.put(e)
 		comp_event.set()
@@ -174,7 +174,7 @@ def async_call(parent, fn, timeout_in_ms=500, cancellable=False):
 	comp_var = Tk.IntVar()
 	comp_var.set(0)
 	comp_event = threading.Event()
-	comp_queue = Queue.Queue()
+	comp_queue = queue.Queue()
 
 	t = threading.Thread(target=async_fn_wrapper,
 			args=(fn, comp_event, comp_queue))
@@ -188,10 +188,10 @@ def async_call(parent, fn, timeout_in_ms=500, cancellable=False):
 	if comp_var.get() == -1:
 		win = ModalWindow(parent)
 		win.title = "Long Running Task..."
-		ttk.Label(win, text="A requested command is taking too long to run",
+		tkinter.ttk.Label(win, text="A requested command is taking too long to run",
 				).pack()
-		ttk.Label(win, text="The long-running command is:").pack()
-		ttk.Label(win, text=str(m3_logging.fn_to_source(fn))).pack()
+		tkinter.ttk.Label(win, text="The long-running command is:").pack()
+		tkinter.ttk.Label(win, text=str(m3_logging.fn_to_source(fn))).pack()
 
 		if cancellable:
 			def cancel_async_call(win):
@@ -287,7 +287,7 @@ class Configuration(M3Gui):
 
 		self.status_label_text = Tk.StringVar(self.top)
 		self.status_label_text.set("< Uninitialized Text >")
-		self.status_label = ttk.Label(self.top, textvariable=self.status_label_text)
+		self.status_label = tkinter.ttk.Label(self.top, textvariable=self.status_label_text)
 		self.status_label.pack()
 
 		self.config_dir = os.path.join(os.getcwd(), 'configs')
@@ -378,7 +378,7 @@ class Configuration(M3Gui):
 			self.use_selected()
 
 	def change_directory(self):
-		new_dir = tkFileDialog.askdirectory(
+		new_dir = tkinter.filedialog.askdirectory(
 				initialdir=self.config_dir,
 				mustexist=True,
 				parent=self.top,
@@ -392,7 +392,7 @@ class Configuration(M3Gui):
 			return
 		else:
 			logger.error('Illegar dir: ' + str(new_dir))
-			tkMessageBox.showerror("Illegal Directory", "Please select a "\
+			tkinter.messagebox.showerror("Illegal Directory", "Please select a "\
 			"directory that actually exists. (As an aside: How did you "\
 			"manage to select one that doesn't exist?)")
 			return self.change_directory()
@@ -401,33 +401,33 @@ class Configuration(M3Gui):
 		def create_new_user():
 			uniq = entry.get()
 			if uniq in self.users:
-				tkMessageBox.showerror("Duplicate User",
+				tkinter.messagebox.showerror("Duplicate User",
 						"A user with that uniqname already exists.")
 			elif len(uniq):
 				new.destroy()
 				self.uniqname_var.set(uniq)
 				self.config_file = os.path.join(self.config_dir, uniq + '.ini')
-				self.config = ConfigParser.SafeConfigParser()
+				self.config = configparser.SafeConfigParser()
 				self.edit_configuration(cancellable=True)
 			else:
-				tkMessageBox.showerror("Blank uniqname",
+				tkinter.messagebox.showerror("Blank uniqname",
 						"Please enter a uniqname.")
 
 		new = ModalWindow(self.top, cancellable=True)
 		new.title('Create New User')
 
-		row0 = ttk.Frame(new)
+		row0 = tkinter.ttk.Frame(new)
 		row0.pack()
 
-		label = ttk.Label(row0, text="uniqname")
+		label = tkinter.ttk.Label(row0, text="uniqname")
 		label.pack(side=Tk.LEFT)
 
-		entry = ttk.Entry(row0)
+		entry = tkinter.ttk.Entry(row0)
 		entry.pack(fill=Tk.X)
 		add_returns(entry, create_new_user)
 		entry.focus_set()
 
-		row1 = ttk.Frame(new)
+		row1 = tkinter.ttk.Frame(new)
 		row1.pack(fill=Tk.X)
 
 		create = ButtonWithReturns(row1, text="Create", command=create_new_user)
@@ -447,7 +447,7 @@ class Configuration(M3Gui):
 
 	def parse_config(self, force_edit=False):
 		logger.debug('parse_config(force_eidt={})'.format(force_edit))
-		self.config = ConfigParser.SafeConfigParser()
+		self.config = configparser.SafeConfigParser()
 		self.config.read(self.config_file)
 		if force_edit:
 			self.edit_configuration(cancellable=False)
@@ -456,7 +456,7 @@ class Configuration(M3Gui):
 				self.last_updated = self.config.getint('DEFAULT', 'last-updated')
 				cur_time = int(time.time())
 				if cur_time - self.last_updated > M3Gui.ONE_DAY:
-					tkMessageBox.showinfo("Stale config file",
+					tkinter.messagebox.showinfo("Stale config file",
 							"Configuration file has not been"\
 							" updated in over 24 hours. Please verify that"\
 							" all information is still correct.")
@@ -464,8 +464,8 @@ class Configuration(M3Gui):
 				self.ws_var.set(self.config.get('DEFAULT', 'workstation'))
 				self.cs_var.set(self.config.get('DEFAULT', 'chips'))
 				self.notes_var.set(self.config.get('DEFAULT', 'notes'))
-			except ConfigParser.NoOptionError:
-				tkMessageBox.showwarning("Bad config file",
+			except configparser.NoOptionError:
+				tkinter.messagebox.showwarning("Bad config file",
 						"Configuration file corrupt."\
 						" Please update your configuration.")
 				self.edit_configuration(cancellable=False)
@@ -490,16 +490,16 @@ class Configuration(M3Gui):
 			cs = cs_var_new.get()
 			notes = notes_text.get(1.0, Tk.END).strip()
 			if ws[0] == '<':
-				tkMessageBox.showerror("No Workstation Selected",
+				tkinter.messagebox.showerror("No Workstation Selected",
 						"Please select a workstation")
 				return
 			if cs[0] == '<':
-				tkMessageBox.showerror("No Chips / Stack Selected",
+				tkinter.messagebox.showerror("No Chips / Stack Selected",
 						"Please select the chips / stacks you are currently"\
 						" using for testing.")
 				return
 			if len(notes) < 10 or notes.strip() == default_notes:
-				tkMessageBox.showerror("No testing notes added",
+				tkinter.messagebox.showerror("No testing notes added",
 						"Please add some notes on what you are currently"\
 						" working on. Add some detail (at least 10 characters)"\
 						" it may be important for you to be able to look this"\
@@ -548,11 +548,11 @@ class Configuration(M3Gui):
 		edit.protocol("WM_DELETE_WINDOW", exit_handler)
 		edit.bind("<Escape>", lambda event : exit_handler())
 
-		label = ttk.Label(edit,
+		label = tkinter.ttk.Label(edit,
 				text="Editing configuration for " + self.uniqname_var.get())
 		label.grid(row=0, columnspan=2)
 
-		ws_label = ttk.Label(edit, text="Workstation")
+		ws_label = tkinter.ttk.Label(edit, text="Workstation")
 		ws_label.grid(row=1, column=0, sticky='e')
 
 		ws_var_new = Tk.StringVar(edit)
@@ -566,13 +566,13 @@ class Configuration(M3Gui):
 					continue
 				ws_list.append(line)
 		except IOError:
-			tkMessageBox.showerror('Missing Workstation List',
+			tkinter.messagebox.showerror('Missing Workstation List',
 					'Configs directory is missing required file:'\
 					' "workstations.txt".')
 			self.parent.destroy()
 			sys.exit()
 		if len(ws_list) == 0:
-			tkMessageBox.showerror('Empty Workstation List',
+			tkinter.messagebox.showerror('Empty Workstation List',
 					'There must be at least one entry in workstations.txt')
 			self.parent.destroy()
 			sys.exit()
@@ -581,7 +581,7 @@ class Configuration(M3Gui):
 
 		try:
 			ws_var_new.set(self.config.get('DEFAULT', 'workstation'))
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			ws_var_new.set('< Select Workstation >')
 			if not focused:
 				ws_option.focus_set()
@@ -595,7 +595,7 @@ class Configuration(M3Gui):
 					return r
 				l = '\n'.join(s(chips_tree) + s(stacks_tree))
 				if len(l) == 0:
-					tkMessageBox.showerror('No Chips Selected', 'You must'\
+					tkinter.messagebox.showerror('No Chips Selected', 'You must'\
 							' select at least on chip or stack.')
 					return
 				selected_label.set(l)
@@ -624,13 +624,13 @@ class Configuration(M3Gui):
 									except ValueError:
 										start = s
 										end = s
-									for i in xrange(int(start), int(end)+1):
+									for i in range(int(start), int(end)+1):
 										ll.append("{}".format(i))
 								l.append((txt, ll))
 							except:
 								logger.warn("Ignoring bad chip/stack entry: " + line)
 				except IOError:
-					tkMessageBox.showerror('Missing Chip / Stack List',
+					tkinter.messagebox.showerror('Missing Chip / Stack List',
 							'Configs directory is missing required file: ' + f)
 					self.parent.destroy()
 					sys.exit()
@@ -643,18 +643,18 @@ class Configuration(M3Gui):
 			stacks = parse_cs_file(stacksf)
 
 			if (len(chips) is 0) and (len(stacks) is 0):
-				tkMessageBox.showerror("Empty Chips and Stacks",
+				tkinter.messagebox.showerror("Empty Chips and Stacks",
 						'At least one chip or stack must be defined.'\
 								' Both chips.txt and stacks.txt are empty.')
 				self.parent.destroy()
 				sys.exit()
 
-			title = ttk.Label(selector, text="Select the chips and / or"\
+			title = tkinter.ttk.Label(selector, text="Select the chips and / or"\
 					" stacks you are currently testing. Hold the Shift or"\
 					" Control keys to select multiple.")
 			title.grid(row=0, columnspan=2, stick='we')
 
-			chips_tree = ttk.Treeview(selector, height=40)
+			chips_tree = tkinter.ttk.Treeview(selector, height=40)
 			for model, numbers in chips:
 				chips_tree.insert('', 'end', model, text=model, open=True)
 				for n in numbers:
@@ -662,7 +662,7 @@ class Configuration(M3Gui):
 					chips_tree.insert(model, 'end', name, text=name)
 			chips_tree.grid(row=1, column=0, sticky='ns')
 
-			stacks_tree = ttk.Treeview(selector, height=40)
+			stacks_tree = tkinter.ttk.Treeview(selector, height=40)
 			for model, numbers in stacks:
 				stacks_tree.insert('', 'end', model, text=model, open=True)
 				for n in numbers:
@@ -687,12 +687,12 @@ class Configuration(M3Gui):
 			cancel.grid(row=3, column=0, sticky='e')
 
 
-		cs_label = ttk.Label(edit, text="Chips / Stacks")
+		cs_label = tkinter.ttk.Label(edit, text="Chips / Stacks")
 		cs_label.grid(row=2, column=0, sticky='ne')
 
 		cs_var_new = Tk.StringVar(edit)
 
-		cs_active_label = ttk.Label(edit, textvariable=cs_var_new)
+		cs_active_label = tkinter.ttk.Label(edit, textvariable=cs_var_new)
 		cs_active_label.grid(row=2, column=1)
 
 		cs_btn = ButtonWithReturns(edit, text="Select Chips / Stacks",
@@ -701,13 +701,13 @@ class Configuration(M3Gui):
 
 		try:
 			cs_var_new.set(self.config.get('DEFAULT', 'chips'))
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			cs_var_new.set('< No Chips / Stacks Selected >')
 			if not focused:
 				cs_btn.focus_set()
 				focused = True
 
-		notes_label = ttk.Label(edit, text="Notes:")
+		notes_label = tkinter.ttk.Label(edit, text="Notes:")
 		notes_label.grid(row=4, columnspan=2, sticky='w')
 
 		notes_text = Tk.Text(edit)
@@ -716,7 +716,7 @@ class Configuration(M3Gui):
 
 		try:
 			notes_text.insert(Tk.INSERT, self.config.get('DEFAULT', 'notes'))
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			notes_text.insert(Tk.INSERT, default_notes)
 			if not focused:
 				notes_text.focus_set()
@@ -747,7 +747,7 @@ class ConfigPane(M3Gui):
 		if hasattr(self.configuration, 'quit'):
 			sys.exit()
 
-		self.config_container = ttk.Frame(parent,
+		self.config_container = tkinter.ttk.Frame(parent,
 				height=800,
 				width=200,
 				borderwidth=5,
@@ -768,23 +768,23 @@ class ConfigPane(M3Gui):
 				self.configuration.edit_configuration(cancellable=True),
 				).pack(fill=Tk.X)
 
-		ttk.Label(self.config_container, text="User:").pack(anchor='w')
-		self.user_label = ttk.Label(self.config_container,
+		tkinter.ttk.Label(self.config_container, text="User:").pack(anchor='w')
+		self.user_label = tkinter.ttk.Label(self.config_container,
 			textvariable=self.configuration.uniqname_var)
 		self.user_label.pack(padx='5m', anchor='w')
 
-		ttk.Label(self.config_container, text="Workstation:").pack(anchor='w')
+		tkinter.ttk.Label(self.config_container, text="Workstation:").pack(anchor='w')
 		self.ws_label = Tk.Label(self.config_container,
 				textvariable=self.configuration.ws_var)
 		self.ws_label.pack(padx='5m', anchor='w')
 
-		ttk.Label(self.config_container, text="Chips / Stacks:").pack(anchor='w')
-		self.chips_label = ttk.Label(self.config_container,
+		tkinter.ttk.Label(self.config_container, text="Chips / Stacks:").pack(anchor='w')
+		self.chips_label = tkinter.ttk.Label(self.config_container,
 			textvariable=self.configuration.cs_var)
 		self.chips_label.pack(padx='5m', anchor='w')
 
-		ttk.Label(self.config_container, text="Notes:").pack(anchor='w')
-		self.notes_label = ttk.Label(self.config_container,
+		tkinter.ttk.Label(self.config_container, text="Notes:").pack(anchor='w')
+		self.notes_label = tkinter.ttk.Label(self.config_container,
 			textvariable=self.configuration.notes_var, wraplength=150)
 		self.notes_label.pack(padx='5m', anchor='w')
 
@@ -793,9 +793,9 @@ class ConfigPane(M3Gui):
 			self.lastup_var.set(pretty_time(self.configuration.last_updated))
 		else:
 			self.lastup_var.set('Error! Corrupt configuration file')
-		self.lastup_label = ttk.Label(self.config_container, textvariable=self.lastup_var)
+		self.lastup_label = tkinter.ttk.Label(self.config_container, textvariable=self.lastup_var)
 		self.lastup_label.pack(side=Tk.BOTTOM, padx='5m', anchor='sw')
-		ttk.Label(self.config_container, text="Config Last Updated:").pack(side=Tk.BOTTOM, anchor='sw')
+		tkinter.ttk.Label(self.config_container, text="Config Last Updated:").pack(side=Tk.BOTTOM, anchor='sw')
 
 class MainPane(M3Gui):
 	def __init__(self, parent, args, config):
@@ -803,7 +803,7 @@ class MainPane(M3Gui):
 		self.args = args
 		self.config = config
 
-		self.mainpane = ttk.Frame(parent,
+		self.mainpane = tkinter.ttk.Frame(parent,
 				borderwidth=5,
 				relief=Tk.RIDGE,
 				height=800,
@@ -822,18 +822,18 @@ class MainPane(M3Gui):
 		self.on_ice_connect = []
 		self.on_ice_disconnect = []
 
-		self.async_event_queue = Queue.Queue()
+		self.async_event_queue = queue.Queue()
 		def async_event_handler():
 			try:
 				while True:
 					self.async_event_queue.get_nowait()()
-			except Queue.Empty:
+			except queue.Empty:
 				pass
 			self.parent.after(50, async_event_handler)
 		self.parent.after_idle(async_event_handler)
 
 		# Bar holding ICE status / info / etc
-		self.icepane = ttk.LabelFrame(self.mainpane, text="ICE")
+		self.icepane = tkinter.ttk.LabelFrame(self.mainpane, text="ICE")
 		self.icepane.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY,
 				ipadx=self.FRAME_IPADX, ipady=self.FRAME_IPADY)
@@ -916,7 +916,7 @@ class MainPane(M3Gui):
 				if last_serial not in port_list:
 					port_list.insert(0, last_serial)
 				self.port_selector_var.set(last_serial)
-			except (ConfigParser.NoOptionError, ValueError):
+			except (configparser.NoOptionError, ValueError):
 				if hasattr(self, 'ice') and self.ice.is_connected():
 					self.port_selector_var.set(self.ice.dev.portstr)
 				else:
@@ -933,17 +933,17 @@ class MainPane(M3Gui):
 
 		self.port_selector_var = Tk.StringVar()
 		self.port_selector_var.trace('w', serial_port_changed)
-		self.port_selector = ttk.OptionMenu(self.icepane, self.port_selector_var)
+		self.port_selector = tkinter.ttk.OptionMenu(self.icepane, self.port_selector_var)
 		populate_serial_port_list()
 		self.port_selector.pack(side=Tk.LEFT)
 
 		self.ice_status_var = Tk.StringVar()
 		self.ice_status_var.set('Not connected to ICE')
-		ttk.Label(self.icepane, textvariable=self.ice_status_var
+		tkinter.ttk.Label(self.icepane, textvariable=self.ice_status_var
 				).pack(fill='y', expand=1, anchor='e')
 
 		# Bar with Power control information
-		self.powerpane = ttk.LabelFrame(self.mainpane, text="Power Control")
+		self.powerpane = tkinter.ttk.LabelFrame(self.mainpane, text="Power Control")
 		self.powerpane.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
@@ -965,8 +965,8 @@ class MainPane(M3Gui):
 			if onoff or force_settle:
 				win = ModalWindow(self.parent)
 				win.title = "Applying power setting"
-				ttk.Label(win, text="Waiting for power rail to settle...").pack()
-				pb = ttk.Progressbar(win, length=300, maximum=settle_time/ .050)
+				tkinter.ttk.Label(win, text="Waiting for power rail to settle...").pack()
+				pb = tkinter.ttk.Progressbar(win, length=300, maximum=settle_time/ .050)
 				pb.pack()
 				pb.start()
 				win.after(settle_time * 1000, lambda : win.destroy())
@@ -985,7 +985,7 @@ class MainPane(M3Gui):
 			def apply_cfg(rail, key, dfl, var):
 				try:
 					voltage = self.config.getfloat('DEFAULT', key)
-				except ConfigParser.NoOptionError:
+				except configparser.NoOptionError:
 					voltage = dfl
 				apply_voltage(rail, voltage, False, var)
 
@@ -1003,9 +1003,9 @@ class MainPane(M3Gui):
 			for v in (self.power0P6_var, self.power1P2_var, self.powervbatt_var):
 				v.set('ICE disconnected')
 
-		self.powerframe1 = ttk.Frame(self.powerpane)
+		self.powerframe1 = tkinter.ttk.Frame(self.powerpane)
 		self.powerframe1.pack(fill='x', expand=1)
-		ttk.Label(self.powerframe1, text="0.6 V Rail:").pack(side='left')
+		tkinter.ttk.Label(self.powerframe1, text="0.6 V Rail:").pack(side='left')
 		self.power0P6_onoff = Tk.IntVar()
 		self.power0P6_onoff.set(0)
 		self.power0P6_off = Tk.Radiobutton(self.powerframe1, text="Off",
@@ -1018,7 +1018,7 @@ class MainPane(M3Gui):
 						apply_power_onoff(self.ice.POWER_0P6, True,
 							self.power0P6_on, self.power0P6_var))
 		self.power0P6_on.pack(side='left')
-		self.power0P6_entry = ttk.Entry(self.powerframe1)
+		self.power0P6_entry = tkinter.ttk.Entry(self.powerframe1)
 		add_returns(self.power0P6_entry,
 				lambda : apply_voltage(self.ice.POWER_0P6, self.power0P6_entry.get(),
 					self.power0P6_onoff.get(), self.power0P6_var))
@@ -1030,11 +1030,11 @@ class MainPane(M3Gui):
 		self.power0P6_btn.pack(side='left')
 		self.power0P6_var = Tk.StringVar()
 		self.power0P6_var.set('ICE disconnected')
-		ttk.Label(self.powerframe1, textvariable=self.power0P6_var).pack(anchor='e')
+		tkinter.ttk.Label(self.powerframe1, textvariable=self.power0P6_var).pack(anchor='e')
 
-		self.powerframe2 = ttk.Frame(self.powerpane)
+		self.powerframe2 = tkinter.ttk.Frame(self.powerpane)
 		self.powerframe2.pack(fill='x', expand=1)
-		ttk.Label(self.powerframe2, text="1.2 V Rail:").pack(side='left')
+		tkinter.ttk.Label(self.powerframe2, text="1.2 V Rail:").pack(side='left')
 		self.power1P2_onoff = Tk.IntVar()
 		self.power1P2_onoff.set(0)
 		self.power1P2_off = Tk.Radiobutton(self.powerframe2, text="Off",
@@ -1047,7 +1047,7 @@ class MainPane(M3Gui):
 						apply_power_onoff(self.ice.POWER_1P2, True,
 							self.power1P2_on, self.power1P2_var))
 		self.power1P2_on.pack(side='left')
-		self.power1P2_entry = ttk.Entry(self.powerframe2)
+		self.power1P2_entry = tkinter.ttk.Entry(self.powerframe2)
 		add_returns(self.power1P2_entry,
 				lambda : apply_voltage(self.ice.POWER_1P2, self.power1P2_entry.get(),
 					self.power1P2_onoff.get(), self.power1P2_var))
@@ -1059,11 +1059,11 @@ class MainPane(M3Gui):
 		self.power1P2_btn.pack(side='left')
 		self.power1P2_var = Tk.StringVar()
 		self.power1P2_var.set('ICE disconnected')
-		ttk.Label(self.powerframe2, textvariable=self.power1P2_var).pack(anchor='e')
+		tkinter.ttk.Label(self.powerframe2, textvariable=self.power1P2_var).pack(anchor='e')
 
-		self.powerframe3 = ttk.Frame(self.powerpane)
+		self.powerframe3 = tkinter.ttk.Frame(self.powerpane)
 		self.powerframe3.pack(fill='x', expand=1)
-		ttk.Label(self.powerframe3, text="VBatt Rail:").pack(side='left')
+		tkinter.ttk.Label(self.powerframe3, text="VBatt Rail:").pack(side='left')
 		self.powervbatt_onoff = Tk.IntVar()
 		self.powervbatt_onoff.set(0)
 		self.powervbatt_off = Tk.Radiobutton(self.powerframe3, text="Off",
@@ -1076,7 +1076,7 @@ class MainPane(M3Gui):
 						apply_power_onoff(self.ice.POWER_VBATT, True,
 							self.powervbatt_on, self.powervbatt_var))
 		self.powervbatt_on.pack(side='left')
-		self.powervbatt_entry = ttk.Entry(self.powerframe3)
+		self.powervbatt_entry = tkinter.ttk.Entry(self.powerframe3)
 		add_returns(self.powervbatt_entry,
 				lambda : apply_voltage(self.ice.POWER_VBATT, self.powervbatt_entry.get(),
 					self.powervbatt_onoff.get(), self.powervbatt_var))
@@ -1088,7 +1088,7 @@ class MainPane(M3Gui):
 		self.powervbatt_btn.pack(side='left')
 		self.powervbatt_var = Tk.StringVar()
 		self.powervbatt_var.set('ICE disconnected')
-		ttk.Label(self.powerframe3, textvariable=self.powervbatt_var).pack(anchor='e')
+		tkinter.ttk.Label(self.powerframe3, textvariable=self.powervbatt_var).pack(anchor='e')
 
 		self.on_ice_connect.append(on_ice_connect_power)
 		self.on_ice_disconnect.append(on_ice_disconnect_power)
@@ -1115,7 +1115,7 @@ class MainPane(M3Gui):
 			apply_power_onoff(self.ice.POWER_0P6, True, self.power0P6_on,
 					self.power0P6_var, force_settle=True)
 
-		self.powerframe4 = ttk.Frame(self.powerpane)
+		self.powerframe4 = tkinter.ttk.Frame(self.powerpane)
 		self.powerframe4.pack(fill='x', expand=1)
 		ButtonWithReturns(self.powerframe4, text="Run M3 Reset Sequence",
 				command = reset_sequence).pack(side='right')
@@ -1125,7 +1125,7 @@ class MainPane(M3Gui):
 				command = power_all_off).pack(side='right')
 
 		# Bar with GOC configuration
-		self.gocpane = ttk.LabelFrame(self.mainpane, text="GOC Configuration")
+		self.gocpane = tkinter.ttk.LabelFrame(self.mainpane, text="GOC Configuration")
 		self.gocpane.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
@@ -1146,17 +1146,17 @@ class MainPane(M3Gui):
 			logger.debug('on_ice_connect_goc_freq')
 			try:
 				apply_goc_freq(self.config.getfloat('DEFAULT', 'goc_freq'))
-			except ConfigParser.NoOptionError:
+			except configparser.NoOptionError:
 				apply_goc_freq(None)
 
-		self.gocframe1 = ttk.Frame(self.gocpane)
+		self.gocframe1 = tkinter.ttk.Frame(self.gocpane)
 		self.gocframe1.pack(fill='x', expand=1)
-		ttk.Label(self.gocframe1, text="Slow Frequency: ").pack(side='left')
-		self.goc_freq_entry = ttk.Entry(self.gocframe1)
+		tkinter.ttk.Label(self.gocframe1, text="Slow Frequency: ").pack(side='left')
+		self.goc_freq_entry = tkinter.ttk.Entry(self.gocframe1)
 		add_returns(self.goc_freq_entry,
 				lambda : apply_goc_freq(self.goc_freq_entry.get()))
 		self.goc_freq_entry.pack(side='left')
-		ttk.Label(self.gocframe1, text="Hz").pack(side='left')
+		tkinter.ttk.Label(self.gocframe1, text="Hz").pack(side='left')
 		self.goc_freq_btn = ButtonWithReturns(self.gocframe1, text="Apply",
 				command=lambda : apply_goc_freq(self.goc_freq_entry.get()))
 		self.goc_freq_btn.pack(side='left')
@@ -1165,7 +1165,7 @@ class MainPane(M3Gui):
 		self.on_ice_connect.append(on_ice_connect_goc_freq)
 		self.on_ice_disconnect.append(lambda :\
 				self.goc_freq_var.set('ICE disconnected'))
-		ttk.Label(self.gocframe1, textvariable=self.goc_freq_var).pack(anchor='e')
+		tkinter.ttk.Label(self.gocframe1, textvariable=self.goc_freq_var).pack(anchor='e')
 
 		def apply_goc_pol(is_normal):
 			if is_normal:
@@ -1191,12 +1191,12 @@ class MainPane(M3Gui):
 					apply_goc_pol(True)
 				else:
 					apply_goc_pol(False)
-			except ConfigParser.NoOptionError:
+			except configparser.NoOptionError:
 				apply_goc_pol(not self.ice.goc_get_onoff())
 
-		self.gocframe2 = ttk.Frame(self.gocpane)
+		self.gocframe2 = tkinter.ttk.Frame(self.gocpane)
 		self.gocframe2.pack(fill='x', expand=1)
-		ttk.Label(self.gocframe2, text="Polarity: ").pack(side='left')
+		tkinter.ttk.Label(self.gocframe2, text="Polarity: ").pack(side='left')
 		self.goc_pol_var = Tk.IntVar()
 		self.goc_pol_var.set(0)
 		self.goc_pol_normal = Tk.Radiobutton(self.gocframe2, text="Normal",
@@ -1212,19 +1212,19 @@ class MainPane(M3Gui):
 		self.on_ice_connect.append(on_ice_connect_goc_pol)
 		self.on_ice_disconnect.append(lambda :\
 				self.goc_pol_lbl.set('ICE disconnected'))
-		ttk.Label(self.gocframe2, textvariable=self.goc_pol_lbl).pack(anchor='e')
+		tkinter.ttk.Label(self.gocframe2, textvariable=self.goc_pol_lbl).pack(anchor='e')
 
 		# Bar holding program image / etc
-		self.progpane = ttk.LabelFrame(self.mainpane, text="Program")
+		self.progpane = tkinter.ttk.LabelFrame(self.mainpane, text="Program")
 		self.progpane.pack(fill=Tk.X, expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
-		self.progframe = ttk.Frame(self.progpane)
+		self.progframe = tkinter.ttk.Frame(self.progpane)
 		self.progframe.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
 		def prog_changed():
-			new_file = tkFileDialog.askopenfilename(
+			new_file = tkinter.filedialog.askopenfilename(
 					filetypes=(
 						('program', '*.bin'),
 						('program', '*.hex'),
@@ -1272,19 +1272,19 @@ class MainPane(M3Gui):
 				change_file(None, True)
 
 		self.prog_button_var = Tk.StringVar()
-		self.prog_button = ttk.Button(self.progframe,
+		self.prog_button = tkinter.ttk.Button(self.progframe,
 				textvariable=self.prog_button_var, command=prog_changed)
 		self.prog_button.pack(side=Tk.LEFT)
 
 		self.prog_info_var = Tk.StringVar()
-		ttk.Label(self.progframe, textvariable=self.prog_info_var,
+		tkinter.ttk.Label(self.progframe, textvariable=self.prog_info_var,
 				justify=Tk.RIGHT).pack(fill='y', expand=1, anchor='e')
 
-		self.progactionframe = ttk.Frame(self.progpane)
+		self.progactionframe = tkinter.ttk.Frame(self.progpane)
 		self.progactionframe.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
-		ttk.Label(self.progactionframe, text='Run After Programming:'
+		tkinter.ttk.Label(self.progactionframe, text='Run After Programming:'
 				).pack(side='left')
 		self.prog_run_after_var = Tk.IntVar()
 		self.prog_run_after_yes = Tk.Radiobutton(self.progactionframe,
@@ -1300,7 +1300,7 @@ class MainPane(M3Gui):
 
 		try:
 			runafter = self.config.getboolean('DEFAULT', 'prog_run_after')
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			runafter = True
 		if runafter:
 			self.prog_run_after_yes.select()
@@ -1374,7 +1374,7 @@ class MainPane(M3Gui):
 				c2 = Tk.Checkbutton(goc_win, #state=Tk.DISABLED,
 						text="Wake chip via GOC")
 				c2.pack(fill='x', expand=1, anchor='w')
-				p2 = ttk.Progressbar(goc_win, length=300,
+				p2 = tkinter.ttk.Progressbar(goc_win, length=300,
 						maximum=((2*8)/slow_freq)/.050)
 				p2.pack()
 				fns.append((c2, p2, lambda :\
@@ -1383,7 +1383,7 @@ class MainPane(M3Gui):
 				c6 = Tk.Checkbutton(goc_win, #state=Tk.DISABLED,
 						text="Delay for ~2 sec")
 				c6.pack(fill='x', expand=1, anchor='w')
-				p6 = ttk.Progressbar(goc_win, length=300, maximum=(2/.050))
+				p6 = tkinter.ttk.Progressbar(goc_win, length=300, maximum=(2/.050))
 				p6.pack()
 				fns.append((c6, p6, lambda : time.sleep(2)))
 
@@ -1397,7 +1397,7 @@ class MainPane(M3Gui):
 			c4 = Tk.Checkbutton(goc_win, #state=Tk.DISABLED,
 					text="Send GOC message (~{} seconds)".format(est_time))
 			c4.pack(fill='x', expand=1, anchor='w')
-			p4 = ttk.Progressbar(goc_win, length=300, maximum=(est_time/.050))
+			p4 = tkinter.ttk.Progressbar(goc_win, length=300, maximum=(est_time/.050))
 			p4.pack()
 			fns.append((c4, p4, lambda m=message:\
 					self.ice.goc_send(m, False)))
@@ -1405,7 +1405,7 @@ class MainPane(M3Gui):
 			c5 = Tk.Checkbutton(goc_win, #state=Tk.DISABLED,
 					text="Send extra blink to end transaction")
 			c5.pack(fill='x', expand=1, anchor='w')
-			p5 = ttk.Progressbar(goc_win, length=300,
+			p5 = tkinter.ttk.Progressbar(goc_win, length=300,
 					maximum=((2*8)/(8*slow_freq))/.050)
 			p5.pack()
 			fns.append((c5, p5, lambda :\
@@ -1454,7 +1454,7 @@ class MainPane(M3Gui):
 					logger.debug("Running: " + ' '.join(cmd))
 					try:
 						output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-					except subprocess.CalledProcessError, e:
+					except subprocess.CalledProcessError as e:
 						logger.warn('Build failure. Command was: ' + ' '.join(cmd))
 						logger.warn('Build output:\n' + e.output[:-1])
 						raise
@@ -1477,7 +1477,7 @@ class MainPane(M3Gui):
 								pass
 					new_bd, new_pd = os.path.split(base_dir)
 					if new_bd == base_dir:
-						tkMessageBox.showerror('Build Error',
+						tkinter.messagebox.showerror('Build Error',
 								'Compilation failed. Check output window for details.')
 						break
 					else:
@@ -1491,7 +1491,7 @@ class MainPane(M3Gui):
 				if os.path.getmtime(prog) < os.path.getmtime(source):
 					win = ModalWindow(self.parent)
 					win.title('Program out of date')
-					ttk.Label(win, text='Program source is older than program.'\
+					tkinter.ttk.Label(win, text='Program source is older than program.'\
 							' Would you like to re-compile before loading?').pack()
 					ButtonWithReturnsAndEscape(win, text="No", command = lambda :\
 							win.destroy()).pack(side='right')
@@ -1515,7 +1515,7 @@ class MainPane(M3Gui):
 							cwd = os.path.dirname(source),
 							)
 					logger.info(name + ' revision: ' + output)
-				except subprocess.CalledProcessError, e:
+				except subprocess.CalledProcessError as e:
 					logger.warn('Failed to get current revision. Command was: '+\
 							' '.join(cmd))
 					logger.warn('Command output:\n' + e.output[:-1])
@@ -1531,7 +1531,7 @@ class MainPane(M3Gui):
 						logger.info(name + ' has uncommitted changes:\n' + output)
 					else:
 						logger.debug(name + ' has no uncommitted changes.')
-				except subprocess.CalledProcessError, e:
+				except subprocess.CalledProcessError as e:
 					logger.warn('Failed to get diff. Command was: '+ ' '.join(cmd))
 					logger.warn('Command output:\n' + e.output[:-1])
 			else:
@@ -1553,11 +1553,11 @@ class MainPane(M3Gui):
 
 		try:
 			change_file(self.config.get('DEFAULT', 'program'))
-		except ConfigParser.NoOptionError:
+		except configparser.NoOptionError:
 			change_file('', force_select=True)
 
 		# Bar with commands
-		self.messagepane = ttk.LabelFrame(self.mainpane, text="Custom Messages")
+		self.messagepane = tkinter.ttk.LabelFrame(self.mainpane, text="Custom Messages")
 		self.messagepane.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
@@ -1602,33 +1602,33 @@ class MainPane(M3Gui):
 				self.message_send_goc.configure(state=Tk.NORMAL)
 				self.message_send_goc_no_wakeup.configure(state=Tk.NORMAL)
 
-		self.messageframe = ttk.Frame(self.messagepane)
+		self.messageframe = tkinter.ttk.Frame(self.messagepane)
 		self.messageframe.pack(fill='x', expand=1)
-		ttk.Label(self.messageframe, text='Address').pack(side='left')
-		self.message_addr = ttk.Entry(self.messageframe)
+		tkinter.ttk.Label(self.messageframe, text='Address').pack(side='left')
+		self.message_addr = tkinter.ttk.Entry(self.messageframe)
 		self.message_addr.pack(side='left')
 		self.message_addr.bind('<Key>', lambda e :\
 				self.message_addr.after_idle(validate_command))
-		ttk.Label(self.messageframe, text='Data').pack(side='left')
-		self.message_data = ttk.Entry(self.messageframe)
+		tkinter.ttk.Label(self.messageframe, text='Data').pack(side='left')
+		self.message_data = tkinter.ttk.Entry(self.messageframe)
 		self.message_data.pack(side='left')
 		self.message_data.bind('<Key>', lambda e :\
 				self.message_data.after_idle(validate_command))
-		ttk.Label(self.messageframe, text='(All values hex)').pack(side='left')
+		tkinter.ttk.Label(self.messageframe, text='(All values hex)').pack(side='left')
 
 		self.message_contents_var = Tk.StringVar()
 		self.message_contents_var.set("Empty Address")
-		ttk.Label(self.messageframe, textvariable=self.message_contents_var
+		tkinter.ttk.Label(self.messageframe, textvariable=self.message_contents_var
 				).pack(side='right')
 
-		self.messageactionframe = ttk.Frame(self.messagepane)
+		self.messageactionframe = tkinter.ttk.Frame(self.messagepane)
 		self.messageactionframe.pack(fill='x', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
 		def select_preprogrammed_command(cmd):
 			if cmd == 'Select Common Message...':
 				return
-			addr, data = map(str.strip, cmd.split('(')[1][:-1].split(','))
+			addr, data = list(map(str.strip, cmd.split('(')[1][:-1].split(',')))
 			self.message_addr.delete(0, Tk.END)
 			self.message_addr.insert(0, addr[2:])
 			self.message_data.delete(0, Tk.END)
@@ -1642,7 +1642,7 @@ class MainPane(M3Gui):
 				"SNS Sample Setup   (0x40, 0x030bf0f0)",
 				"SNS Sample Start   (0x40, 0x030af0f0)",
 				)
-		self.message_defaults = ttk.OptionMenu(self.messageactionframe,
+		self.message_defaults = tkinter.ttk.OptionMenu(self.messageactionframe,
 				self.message_defaults_var, *default_messages,
 				command = select_preprogrammed_command)
 		self.message_defaults.pack(side='left')
@@ -1683,7 +1683,7 @@ class MainPane(M3Gui):
 		self.message_send_goc_no_wakeup.pack(side='right')
 
 		# Interface for live session
-		self.actionpane = ttk.LabelFrame(self.mainpane, text='Action Pane')
+		self.actionpane = tkinter.ttk.LabelFrame(self.mainpane, text='Action Pane')
 		self.actionpane.pack(fill='both', expand=1,
 				padx=self.FRAME_PADX, pady=self.FRAME_PADY)
 
@@ -1707,14 +1707,14 @@ class MainPane(M3Gui):
 				self.window.tag_config( 'err', foreground='red')
 				self.window.tag_config( 'dbg', foreground='cyan')
 
-				self.queue = Queue.Queue()
+				self.queue = queue.Queue()
 				self.process_events()
 
 			def process_events(self):
 				try:
 					while True:
 						self.queue.get_nowait()()
-				except Queue.Empty:
+				except queue.Empty:
 					pass
 				self.window.after(100, self.process_events)
 
@@ -1776,7 +1776,7 @@ class MainPane(M3Gui):
 		# modify the logging configuration to add our handler as another
 		# handler that is installed by default. But I don't know how to do that
 		# and it doesn't matter yet, so... tomorrow Pat's problem.
-		for l in logging.Logger.manager.loggerDict.values():
+		for l in list(logging.Logger.manager.loggerDict.values()):
 			if not isinstance(l, logging.PlaceHolder):
 				l.addHandler(self.terminal_logger_handler)
 
@@ -1806,7 +1806,7 @@ def setup_file_logger(config_file, uniq):
 	file_handler = SyncingFileHandler(logfile, delay=True)
 	file_handler.level = logging.DEBUG
 	file_handler.formatter = file_formatter
-	for l in logging.Logger.manager.loggerDict.values():
+	for l in list(logging.Logger.manager.loggerDict.values()):
 		if not isinstance(l, logging.PlaceHolder):
 			l.addHandler(file_handler)
 	setup_file_logger.logfile = logfile
@@ -1819,8 +1819,8 @@ if __name__ == '__main__':
 
 	root = Tk.Tk()
 
-	style = ttk.Style()
-	ttk.Style().theme_use('alt')
+	style = tkinter.ttk.Style()
+	tkinter.ttk.Style().theme_use('alt')
 
 	#print(style.layout('TLabel'))
 	#print(style.element_options('Label.border'))

--- a/platforms/m3/programming/m3_common.py
+++ b/platforms/m3/programming/m3_common.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+
 
 import atexit
 import os
 import sys
 import socket
-from Queue import Queue
+from queue import Queue
 import argparse
 import time
 import threading
@@ -42,7 +42,7 @@ class m3_common(object):
 
     def default_value(self, prompt, default, extra=None, invert=False):
         if invert and (extra is None):
-            raise RuntimeError, "invert & !extra ?"
+            raise RuntimeError("invert & !extra ?")
         if self.args.yes:
             fn = print
         else:
@@ -140,7 +140,7 @@ class m3_common(object):
 
         # Bit-wise XOR parity of header
         header_parity = 0
-        for byte in [HEADER[x:x+2] for x in xrange(0, len(HEADER), 2)]:
+        for byte in [HEADER[x:x+2] for x in range(0, len(HEADER), 2)]:
             byte = int(byte, 16)
             header_parity ^= byte
         HEADER += "%02X" % (header_parity)
@@ -154,7 +154,7 @@ class m3_common(object):
 
             # Bit-wise XOR parity of data
             data_parity = 0
-            for byte in [DATA[x:x+2] for x in xrange(0, len(DATA), 2)]:
+            for byte in [DATA[x:x+2] for x in range(0, len(DATA), 2)]:
                 b = int(byte, 16)
                 data_parity ^= b
 
@@ -383,10 +383,10 @@ class m3_common(object):
         else:
             def pick_serial():
                 logger.info("Multiple possible serial ports found:")
-                for i in xrange(len(candidates)):
+                for i in range(len(candidates)):
                     logger.info("\t[{}] {}".format(i, candidates[i]))
                 try:
-                    resp = raw_input("Choose a serial port (Ctrl-C to quit): ").strip()
+                    resp = input("Choose a serial port (Ctrl-C to quit): ").strip()
                 except KeyboardInterrupt:
                     sys.exit(1)
                 try:

--- a/platforms/m3/programming/mbus_snoop.py
+++ b/platforms/m3/programming/mbus_snoop.py
@@ -29,7 +29,7 @@ class mbus_message_generator(m3_common):
         reset_event.set()
 
         #print("  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
-        print("@ Time: " + time.strftime("%Y-%m-%d %H:%M:%S") + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
+        print(("@ Time: " + time.strftime("%Y-%m-%d %H:%M:%S") + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"))
 
     def read_binfile(self):
         pass

--- a/platforms/m3/programming/mbus_snoop_img.py
+++ b/platforms/m3/programming/mbus_snoop_img.py
@@ -47,7 +47,7 @@ class mbus_message_generator(m3_common):
         self.ice.msg_handler['b++'] = self.Bpp_callback
 
     def Bpp_callback(self, address, data, cb0, cb1):
-        print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
+        print(("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"))
 
     def read_binfile(self):
         pass

--- a/platforms/m3/programming/mbus_snoop_img2.py
+++ b/platforms/m3/programming/mbus_snoop_img2.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 
 
 def Bpp_callback(address, data, cb0, cb1):
-	print(" Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
+	print((" Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"))
 
 m = m3_common.mbus_snooper(Bpp_callback)
 m.hang_for_messages()

--- a/platforms/m3/programming/mbus_snoop_inhee.py
+++ b/platforms/m3/programming/mbus_snoop_inhee.py
@@ -29,7 +29,7 @@ class mbus_message_generator(m3_common):
         reset_event.set()
 
         #print("  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
-        print("@ Time: " + time.strftime("%Y-%m-%d %H:%M:%S") + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
+        print(("@ Time: " + time.strftime("%Y-%m-%d %H:%M:%S") + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"))
 
     def read_binfile(self):
         pass

--- a/platforms/m3/programming/mbus_snoop_rdcv1_dual.py
+++ b/platforms/m3/programming/mbus_snoop_rdcv1_dual.py
@@ -62,8 +62,8 @@ class mbus_message_generator(m3_common):
 
     def Bpp_callback(self, address, data, cb0=-1, cb1=-1):
 
-		print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + binascii.hexlify(address)+ "  DATA: 0x" + binascii.hexlify(data) + "  (ACK: " + str(not cb1) + ")")
-		print >> logfile, "@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + binascii.hexlify(address) + "  DATA: 0x" + binascii.hexlify(data)+ "  (ACK: " + str(not cb1) + ")"
+		print(("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + binascii.hexlify(address)+ "  DATA: 0x" + binascii.hexlify(data) + "  (ACK: " + str(not cb1) + ")"))
+		print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + binascii.hexlify(address) + "  DATA: 0x" + binascii.hexlify(data)+ "  (ACK: " + str(not cb1) + ")", file=logfile)
 		if (str(int(binascii.hexlify(address),16))=="193"):
 			self.rdc_group = True
 			self.rdc1_data = int(binascii.hexlify(data),16)

--- a/platforms/m3/programming/mbus_snoop_snsv6.py
+++ b/platforms/m3/programming/mbus_snoop_snsv6.py
@@ -35,9 +35,9 @@ class mbus_message_generator(m3_common):
     def Bpp_callback(self, address, data, cb0, cb1):
         print("")
         print("Received MBus message:")
-        print("  address: 0x" + address.encode('hex'))
-        print("     data: 0x" + data.encode('hex'))
-        print("was_acked: " + str(not cb1))
+        print(("  address: 0x" + address.encode('hex')))
+        print(("     data: 0x" + data.encode('hex')))
+        print(("was_acked: " + str(not cb1)))
         if (str(int(address.encode('hex'),16))=="118"):
             #o_file.write(str(int(address.encode('hex'),16))+"\t"+str(int(data.encode('hex'),16))+"\r\n")
             o_file_cref.write(str(int(data.encode('hex'),16))+"\n")
@@ -46,7 +46,7 @@ class mbus_message_generator(m3_common):
             o_file_outp.write(str(int(data.encode('hex'),16))+"\n")
             o_file_outp.flush()
             self.count += 1
-        print(self.count)
+        print((self.count))
         if self.count>self.args.killcount:
             self.exit()
 

--- a/platforms/m3/programming/mbus_snoop_snsv6_csv.py
+++ b/platforms/m3/programming/mbus_snoop_snsv6_csv.py
@@ -45,7 +45,7 @@ class mbus_message_generator(m3_common):
         self.ice.msg_handler['b++'] = self.Bpp_callback
 
     def Bpp_callback(self, address, data, cb0, cb1):
-        print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
+        print(("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"))
         if (str(int(address.encode('hex'),16))=="118"):
             #o_file.write(str(int(address.encode('hex'),16))+"\t"+str(int(data.encode('hex'),16))+"\r\n")
 			cdc_cref.append(int(data.encode('hex'),16))
@@ -55,7 +55,7 @@ class mbus_message_generator(m3_common):
             cdc_cmeas.append(int(data.encode('hex'),16))
             self.count += 1
         if self.count>self.args.killcount:
-			rows = zip(cdc_date,cdc_time,cdc_cmeas,cdc_cref)
+			rows = list(zip(cdc_date,cdc_time,cdc_cmeas,cdc_cref))
 			wr = csv.writer(open('snsv6_snoop.txt','w'), delimiter=',', lineterminator='\n')
 			wr.writerow(['DATE','TIME','C_MEAS','C_REF'])
 			for row in rows:

--- a/platforms/m3/programming/mbus_snoop_snsv6_par_csv.py
+++ b/platforms/m3/programming/mbus_snoop_snsv6_par_csv.py
@@ -48,8 +48,8 @@ class mbus_message_generator(m3_common):
         self.ice.msg_handler['b++'] = self.Bpp_callback
 
     def Bpp_callback(self, address, data, cb0=-1, cb1=-1):
-        print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
-        print >> logfile, "@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"
+        print(("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"))
+        print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")", file=logfile)
         if (str(int(address.encode('hex'),16))=="118"):
             #o_file.write(str(int(address.encode('hex'),16))+"\t"+str(int(data.encode('hex'),16))+"\r\n")
 			cdc_cref.append(int(data.encode('hex'),16))
@@ -63,7 +63,7 @@ class mbus_message_generator(m3_common):
             cdc_cmeas.append(int(data.encode('hex'),16))
             self.count += 1
         if self.count>self.args.killcount:
-			rows = zip(cdc_date,cdc_time,cdc_cmeas,cdc_cref,cdc_crev,cdc_cpar)
+			rows = list(zip(cdc_date,cdc_time,cdc_cmeas,cdc_cref,cdc_crev,cdc_cpar))
 			wr = csv.writer(open('snsv6_snoop.txt','w'), delimiter=',', lineterminator='\n')
 			wr.writerow(['DATE','TIME','C_MEAS','C_REF','C_REV','C_PAR'])
 			for row in rows:

--- a/platforms/m3/programming/mbus_snoop_snsv7_double_par_csv.py
+++ b/platforms/m3/programming/mbus_snoop_snsv7_double_par_csv.py
@@ -68,8 +68,8 @@ class mbus_message_generator(m3_common):
 
     def Bpp_callback(self, address, data, cb0=-1, cb1=-1):
 
-		print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + binascii.hexlify(address)+ "  DATA: 0x" + binascii.hexlify(data) + "  (ACK: " + str(not cb1) + ")")
-		print >> logfile, "@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + binascii.hexlify(address) + "  DATA: 0x" + binascii.hexlify(data)+ "  (ACK: " + str(not cb1) + ")"
+		print(("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + binascii.hexlify(address)+ "  DATA: 0x" + binascii.hexlify(data) + "  (ACK: " + str(not cb1) + ")"))
+		print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + binascii.hexlify(address) + "  DATA: 0x" + binascii.hexlify(data)+ "  (ACK: " + str(not cb1) + ")", file=logfile)
 		if (str(int(binascii.hexlify(address),16))=="116"):
 			self.cdc_group = True
 			self.cdc_cmeas = int(binascii.hexlify(data),16)

--- a/platforms/m3/programming/mbus_snoop_snsv7_double_temp_csv.py
+++ b/platforms/m3/programming/mbus_snoop_snsv7_double_temp_csv.py
@@ -49,8 +49,8 @@ class mbus_message_generator(m3_common):
         self.ice.msg_handler['b++'] = self.Bpp_callback
 
     def Bpp_callback(self, address, data, cb0=-1, cb1=-1):
-		print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
-		print >> logfile, "@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"
+		print(("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"))
+		print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")", file=logfile)
 		if (str(int(address.encode('hex'),16))=="116"):
 			self.cdc_group = True
 			self.temp1 = int(data.encode('hex'),16)

--- a/platforms/m3/programming/mbus_snoop_snsv7_par_csv.py
+++ b/platforms/m3/programming/mbus_snoop_snsv7_par_csv.py
@@ -53,8 +53,8 @@ class mbus_message_generator(m3_common):
         self.ice.msg_handler['b++'] = self.Bpp_callback
 
     def Bpp_callback(self, address, data, cb0=-1, cb1=-1):
-		print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
-		print >> logfile, "@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"
+		print(("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"))
+		print("@" + str(self.count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")", file=logfile)
 		if (str(int(address.encode('hex'),16))=="116"):
 			self.cdc_group = True
 			self.cdc_cmeas = int(data.encode('hex'),16)

--- a/platforms/m3/programming/mbus_snoop_yejoong.py
+++ b/platforms/m3/programming/mbus_snoop_yejoong.py
@@ -29,7 +29,7 @@ class mbus_message_generator(m3_common):
         reset_event.set()
 
         #print("  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
-        print("@ Time: " + time.strftime("%Y-%m-%d %H:%M:%S") + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
+        print(("@ Time: " + time.strftime("%Y-%m-%d %H:%M:%S") + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"))
 
     def read_binfile(self):
         pass

--- a/platforms/m3/programming/plot_pstack_radv8.py
+++ b/platforms/m3/programming/plot_pstack_radv8.py
@@ -53,25 +53,25 @@ for line in lines:
 for i in range(0,min(len(cmeas_int),len(cref_int))):
 	cmeas_cal.append(float(cmeas_int[i])/float(cref_int[i])*100000)
 
-print "C_MEASURE:\n"
-print cmeas
-print "\nC_REF:\n"
-print cref
+print("C_MEASURE:\n")
+print(cmeas)
+print("\nC_REF:\n")
+print(cref)
 
-print "\nC_MEASURE:\n"
-print cmeas_int
-print len(cmeas_int)
-print "\nC_REF:\n"
-print cref_int
-print len(cref_int)
+print("\nC_MEASURE:\n")
+print(cmeas_int)
+print(len(cmeas_int))
+print("\nC_REF:\n")
+print(cref_int)
+print(len(cref_int))
 
-print "\nC_MEAS_CALIBRATED:\n"
-print cmeas_cal
-print len(cref_int)
+print("\nC_MEAS_CALIBRATED:\n")
+print(cmeas_cal)
+print(len(cref_int))
 
 
 # Export to CSV
-rows = zip(date,time,cmeas_int,cref_int,cmeas_cal)
+rows = list(zip(date,time,cmeas_int,cref_int,cmeas_cal))
 
 wr = csv.writer(open(output_file,'w'), delimiter=',', lineterminator='\n')
 wr.writerow(['DATE','TIME','C_MEAS','C_REF','C_MEAS_CAL'])
@@ -80,7 +80,7 @@ for row in rows:
 
 fig1 = plt.figure()
 
-plt.plot(range(1,len(cmeas_cal)+1),list(reversed(cmeas_cal)))
+plt.plot(list(range(1,len(cmeas_cal)+1)),list(reversed(cmeas_cal)))
 plt.ylabel('CMEAS/CREF*1E5')
 plt.xlabel('Time (pts)')
 

--- a/platforms/m3/programming/program_via_i2c.py
+++ b/platforms/m3/programming/program_via_i2c.py
@@ -8,7 +8,7 @@ import socket
 import sys
 import os
 import mimetypes
-import Queue
+import queue
 import logging
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger('program')
@@ -77,7 +77,7 @@ def validate_bin_helper(msg_type, event_id, length, msg):
         return
     validate_q.put(msg)
 
-validate_q = Queue.Queue()
+validate_q = queue.Queue()
 ice.msg_handler['d+'] = validate_bin_helper
 
 ice.connect(sys.argv[2])
@@ -106,7 +106,7 @@ logger.info("M3 0.6V => ON")
 ice.power_set_onoff(0,True)
 sleep(4.0)
 
-resp = raw_input("About to send I2C message to wake controller. Continue? [Y/n] ")
+resp = input("About to send I2C message to wake controller. Continue? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     sys.exit()
 
@@ -183,7 +183,7 @@ def validate_bin(ice, hexencoded, offset=0):
     logger.info("Programming validated successfully")
     return True
 
-resp = raw_input("About to send program data to I2C. Continue? [Y/n] ")
+resp = input("About to send program data to I2C. Continue? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     sys.exit()
 
@@ -214,7 +214,7 @@ logger.info('=' * 80)
 logger.info("Programming complete.")
 logger.info("")
 
-resp = raw_input("Would you like to send the DMA start interrupt? [Y/n] ")
+resp = input("Would you like to send the DMA start interrupt? [Y/n] ")
 if len(resp) != 0 and resp[0] in ('n', 'N'):
     sys.exit()
 

--- a/platforms/m3/programming/snsv7_par_csv_callback.py
+++ b/platforms/m3/programming/snsv7_par_csv_callback.py
@@ -23,7 +23,7 @@ def callback(time, address, data, cb0=-1, cb1=-1):
 
     # m3_ice snoop prints this for you now [though needs to add count - can do]
     #print("@" + str(count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")")
-    print >> logfile, "@" + str(count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")"
+    print("@" + str(count) + " Time: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "  ADDR: 0x" + address.encode('hex') + "  DATA: 0x" + data.encode('hex') + "  (ACK: " + str(not cb1) + ")", file=logfile)
     if (str(int(address.encode('hex'),16))=="116"):
         cdc_group = True
         cdc_cmeas = int(data.encode('hex'),16)

--- a/simulator/Tuprules.tup
+++ b/simulator/Tuprules.tup
@@ -17,7 +17,7 @@ CFLAGS += -Wno-type-limits
 CFLAGS += -fno-strict-overflow
 CFLAGS += -Wformat=2 -Winit-self -Wmissing-include-dirs -Wunused-parameter
 CFLAGS += -Wundef -Wpointer-arith -Wbad-function-cast -Wcast-qual -Wfloat-equal
-CFLAGS += -Wwrite-strings -Waggregate-return -Wstrict-prototypes
+CFLAGS += -Wwrite-strings -Wstrict-prototypes
 CFLAGS += -Wmissing-field-initializers -Wmissing-format-attribute
 CFLAGS += -Winline -Wvolatile-register-var -Wdisabled-optimization
 CFLAGS += -Wshadow -Wpacked

--- a/simulator/cli/cli.c
+++ b/simulator/cli/cli.c
@@ -134,12 +134,12 @@ int main(int argc, char **argv) {
 		int option_index = 0;
 		int c;
 
-		char optstring[65] = "g::c:y:aps:erl:Tf:?";
+		char optstring[64] = "g::c:y:aps:erl:Tf:?";
 #ifdef HAVE_DECOMPILE
-		strncat(optstring, "d", 64);
+		strncat(optstring, "d", 63);
 #endif
 #ifdef HAVE_MEMTRACE
-		strncat(optstring, "m", 64);
+		strncat(optstring, "m", 63);
 #endif
 
 		c = getopt_long(argc, argv, optstring, long_options, &option_index);

--- a/simulator/cli/cli.c
+++ b/simulator/cli/cli.c
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
 		int option_index = 0;
 		int c;
 
-		char optstring[64] = "g::c:y:aps:erl:Tf:?";
+		char optstring[65] = "g::c:y:aps:erl:Tf:?";
 #ifdef HAVE_DECOMPILE
 		strncat(optstring, "d", 64);
 #endif

--- a/simulator/core/gdb.c
+++ b/simulator/core/gdb.c
@@ -400,6 +400,7 @@ static bool _wait_for_gdb(void) {
 			// kill
 			INFO("Killed by remote debugger, dying\n");
 			sim_terminate(true);
+			break;
 		}
 
 		case 'm':

--- a/simulator/core/simulator.c
+++ b/simulator/core/simulator.c
@@ -260,6 +260,7 @@ static void _shell(void) {
 		case 'q':
 		case 't':
 			sim_terminate(true);
+			return;
 
 		case 'r':
 		{
@@ -294,9 +295,11 @@ static void _shell(void) {
 				return _shell();
 			}
 		}
+		break;
 
 		case '\n':
 			sprintf(buf, "cycle %d\n", cycle+1);
+			// fall through
 		case 'c':
 			if (buf[1] == 'y') {
 				int requested_cycle;
@@ -317,7 +320,8 @@ static void _shell(void) {
 				dumpatpc = 0;
 				return;
 			}
-			// not 'cy' or 'co', fall thru
+			// not 'cy' or 'co'
+			// fall thru
 
 		case 'h':
 		default:

--- a/simulator/core/simulator.c
+++ b/simulator/core/simulator.c
@@ -295,7 +295,7 @@ static void _shell(void) {
 				return _shell();
 			}
 		}
-		break;
+		// fall thru
 
 		case '\n':
 			sprintf(buf, "cycle %d\n", cycle+1);

--- a/simulator/cpu/373/static_rom.h
+++ b/simulator/cpu/373/static_rom.h
@@ -11,7 +11,7 @@
 // bintoarray.sh; "echo.bin"
 #include <stdint.h>
 #define STATIC_ROM_NUM_BYTES (107 * 4)
-uint32_t static_rom[107];
+extern uint32_t static_rom[107];
 
 #define STATIC_ROM_BLURB "\
 \t\t\techo.bin: Listens for a character on the polling UART\n\

--- a/simulator/cpu/common/private_peripheral_bus/Tupfile
+++ b/simulator/cpu/common/private_peripheral_bus/Tupfile
@@ -1,4 +1,4 @@
 include_rules
 
-: gen_registers.py | exceptions *.conf |> python %f *.conf |> ppb.c ppb.h
+: gen_registers.py | exceptions *.conf |> python3 %f *.conf |> ppb.c ppb.h
 : ppb.c | ppb.h |> !cc |> %B.o ../../../<objs>

--- a/simulator/cpu/common/private_peripheral_bus/gen_registers.py
+++ b/simulator/cpu/common/private_peripheral_bus/gen_registers.py
@@ -141,10 +141,10 @@ for f in sys.argv[1:]:
 		addr = addr.lower()
 
 		# normalize addr to "0x%8"
-		if len(addr) is 10:
+		if len(addr) == 10:
 			if addr[:2] != "0x":
 				raise ParseError(e, "Illegal register address: " + addr)
-		if len(addr) is 8:
+		if len(addr) == 8:
 			a = int(addr, 16)
 			addr = "0x" + str(a)
 
@@ -197,11 +197,11 @@ for f in sys.argv[1:]:
 			if base in ('b', 'B'):
 				for i in range(len(bitstring)):
 					bit = bitstring[i]
-					if bit is '1':
+					if bit == '1':
 						reset += '|(1U<<'+str(i)+')'
-					elif bit is '0':
+					elif bit == '0':
 						reset += '&~(1U<<'+str(i)+')'
-					elif bit is 'x':
+					elif bit == 'x':
 						pass
 					else:
 						raise ParseError(e, 'Bad token ' + bit + ' in binary bitstring')

--- a/simulator/cpu/common/private_peripheral_bus/gen_registers.py
+++ b/simulator/cpu/common/private_peripheral_bus/gen_registers.py
@@ -17,17 +17,17 @@ class ParseError(Error):
 		self.f, self.lineno, self.line = e.cur()
 		self.msg = msg
 	def __str__(self):
-		print ": " + self.msg
-		print
-		print self.f + " line " + str(self.lineno) + ":"
-		print ">>>" + self.line[:-1] + "<<<"
+		print(": " + self.msg)
+		print()
+		print(self.f + " line " + str(self.lineno) + ":")
+		print(">>>" + self.line[:-1] + "<<<")
 
 class EnumerableFile(enumerate):
 	def __new__(self, filename):
 		self.filename = filename
-		return super(EnumerableFile, self).__new__(self, open(self.filename))
-	def next(self):
-		self.c = super(EnumerableFile, self).next()
+		return super().__new__(self, open(self.filename))
+	def __next__(self):
+		self.c = super().__next__()
 		return self.c[1]
 	def cur(self):
 		return self.filename, self.c[0], self.c[1]
@@ -38,21 +38,21 @@ e = EnumerableFile("exceptions")
 try:
 	while True:
 		# Once we've read one line, we know there's a block to parse
-		idx = int(e.next().strip())
+		idx = int(next(e).strip())
 		clean = False
-		module = e.next().strip()
-		register = e.next().strip()
-		description = e.next().strip()
+		module = next(e).strip()
+		register = next(e).strip()
+		description = next(e).strip()
 		while description.count('"""') != 2:
-			description += e.next()
+			description += next(e)
 		description = description.strip()
-		func = e.next()
+		func = next(e)
 		if func.count('{') < 1:
 			raise ParseError(e, "Expected { to begin function. Got: >>>" + func + "<<<")
 		while func.count('{') != func.count('}'):
-			func += e.next()
+			func += next(e)
 		func = func[func.find('{'):]
-		empty = e.next()
+		empty = next(e)
 		if '\n' != empty:
 			raise ParseError(e, "Expected empty line. Got: >>>" + empty + "<<<")
 		clean = True
@@ -105,7 +105,7 @@ for f in sys.argv[1:]:
 	e = EnumerableFile(f)
 	while True:
 		try:
-			line = e.next()
+			line = next(e)
 		except StopIteration:
 			break
 

--- a/simulator/tests/arm_core_test/fix_ldr.py
+++ b/simulator/tests/arm_core_test/fix_ldr.py
@@ -19,36 +19,36 @@ for line in g:
     if -1 != line.find("# Test Complete"):
         o.write(line)
 
-        line = g.next() # B ..._rtn_lbl
-        line = g.next() # '\n'
-        line = g.next() # # Failure
-        fail_lbl = g.next() # ..._led_lbl:
-        line = g.next() # ldr r0, clk_freq / 5
+        line = next(g) # B ..._rtn_lbl
+        line = next(g) # '\n'
+        line = next(g) # # Failure
+        fail_lbl = next(g) # ..._led_lbl:
+        line = next(g) # ldr r0, clk_freq / 5
         if line.find('CLK_FREQ') == -1:
-            print "ERR corrected branch logic. Expected clk line, got:"
-            print ">>>" + line + "<<<"
+            print("ERR corrected branch logic. Expected clk line, got:")
+            print(">>>" + line + "<<<")
             sys.exit(1)
-        line = g.next() # ldr r1, ledLoop
+        line = next(g) # ldr r1, ledLoop
         if line.find('LDR R1, ') == -1:
-            print "ERR corrected branch logic. Expected ldr ledLoop line, got:"
-            print ">>>" + line + "<<<"
+            print("ERR corrected branch logic. Expected ldr ledLoop line, got:")
+            print(">>>" + line + "<<<")
             sys.exit(1)
-        line = g.next() # bx r1
+        line = next(g) # bx r1
         if line.strip() != 'BX  R1':
-            print "ERR corrected branch logic. Expected bx r1, got:"
-            print ">>>" + line.strip() + "<<<"
+            print("ERR corrected branch logic. Expected bx r1, got:")
+            print(">>>" + line.strip() + "<<<")
             sys.exit(1)
-        line = g.next() # '\n'
+        line = next(g) # '\n'
         if line.strip() != '':
-            print "ERR corrected branch logic. Expected blank line, got:"
-            print ">>>" + line.strip() + "<<<"
+            print("ERR corrected branch logic. Expected blank line, got:")
+            print(">>>" + line.strip() + "<<<")
             sys.exit(1)
-        line = g.next() # # Return from function
-        line = g.next() # ...rtn_lbl:
-        line = g.next() # bx lr
+        line = next(g) # # Return from function
+        line = next(g) # ...rtn_lbl:
+        line = next(g) # bx lr
         if line.strip() != 'BX LR':
-            print "ERR corrected branch logic. Expected bx lr, got:"
-            print ">>>" + line.strip() + "<<<"
+            print("ERR corrected branch logic. Expected bx lr, got:")
+            print(">>>" + line.strip() + "<<<")
             sys.exit(1)
 
         o.write('    MOVW R0, 0\n')
@@ -62,8 +62,8 @@ for line in g:
         continue
 
     if -1 != line.find('_led_lbl:'):
-        print "ERR, missed branch correction, line:"
-        print ">>>" + line + "<<<"
+        print("ERR, missed branch correction, line:")
+        print(">>>" + line + "<<<")
         sys.exit(1)
 
     # Re-write the end test sequences
@@ -94,7 +94,7 @@ for line in g:
         o.write(line)
         continue
 
-    print line.rstrip()
+    print(line.rstrip())
     l = line.split()
     try:
         val = int(l[-1], 16)


### PR DESCRIPTION
Let me know if you'd like for me to split the request into two.

Most python3 changes were done by 2to3. I did some manual fixes for some issues I saw while doing a manual review of the changes.

I'm not 100% sure I put `return`/`break` in the right places to fix the compiler complaints (mostly complaining about falling through).