### PR TITLE
atomic_support: remove old GCC code, fix NO_ATOMIC

### DIFF
--- a/simulator/core/atomic_support.c
+++ b/simulator/core/atomic_support.c
@@ -1,0 +1,12 @@
+/* Mulator - An extensible {e,si}mulator
+ * Copyright 2011-2020 Pat Pannuto <pat.pannuto@gmail.com>
+ *
+ * Licensed under either of the Apache License, Version 2.0
+ * or the MIT license, at your option.
+ */
+
+#include "atomic_support.h"
+
+#ifdef NO_ATOMIC
+    pthread_mutex_t no_atomic_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif

--- a/simulator/core/state.c
+++ b/simulator/core/state.c
@@ -67,40 +67,12 @@ static thread_local struct state_change writes[STATE_MAX_WRITES];
 #endif // HAVE_REPLAY
 ////
 
-#ifdef HAVE_STDATOMIC
- #ifndef NO_PIPELINE
-  static atomic_flag pipeline_flush_flag = ATOMIC_FLAG_INIT; // false
- #endif
-
- static atomic_bool debugging_bool = ATOMIC_VAR_INIT(false);
- static atomic_bool wfi_bool = ATOMIC_VAR_INIT(false);
-#elif defined(CLANG_ATOMIC)
- #ifndef NO_PIPELINE
-  static bool pipeline_flush_flag = false;
- #endif
-
- static _Atomic(bool) debugging_bool;
- static _Atomic(bool) wfi_bool;
- __attribute__ ((constructor))
- static void clang_pipeline_atomic_bools_init(void) {
-	 __c11_atomic_init(&debugging_bool, false);
-	 __c11_atomic_init(&wfi_bool, false);
- }
-#elif defined(GCC_ATOMIC)
- #ifndef NO_PIPELINE
-  static bool pipeline_flush_flag = false;
- #endif
-
-  static bool debugging_bool = false;
-  static bool wfi_bool = false;
-#elif defined(NO_ATOMIC)
- #ifndef NO_PIPELINE
-  static bool pipeline_flush_flag = false;
- #endif
- static bool debugging_bool;
- static bool wfi_bool = false;
+#ifndef NO_PIPELINE
+ static atomic_flag pipeline_flush_flag = ATOMIC_FLAG_INIT; // false
 #endif
 
+static atomic_bool debugging_bool = ATOMIC_VAR_INIT(false);
+static atomic_bool wfi_bool = ATOMIC_VAR_INIT(false);
 
 static unsigned pending_async_exception;
 static sem_t *set_pending_async_exception_sem;

--- a/simulator/cpu/core.c
+++ b/simulator/cpu/core.c
@@ -37,7 +37,7 @@ EXPORT void register_reset(void (*fn)(void)) {
 	reset_head = n;
 }
 
-EXPORT _Atomic _Bool _CORE_in_reset = false;
+EXPORT atomic_bool _CORE_in_reset = false;
 EXPORT void reset(void) {
 	atomic_store(&_CORE_in_reset, true);
 #ifdef DEBUG1

--- a/simulator/cpu/core.h
+++ b/simulator/cpu/core.h
@@ -33,7 +33,7 @@ void register_memmap(
 		uint32_t top
 	);
 
-extern _Atomic _Bool	_CORE_in_reset;
+extern atomic_bool	_CORE_in_reset;
 void		reset(void);
 
 uint32_t	read_word_quiet(uint32_t addr);

--- a/simulator/decoder/decoder.c
+++ b/simulator/decoder/decoder.c
@@ -161,7 +161,7 @@ EXPORT void CORE_ufsr_write(union ufsr_t u) {
 
 
 // core
-EXPORT _Atomic _Bool _CORE_in_reset = false;
+EXPORT atomic_bool _CORE_in_reset = false;
 EXPORT uint32_t read_word_quiet(uint32_t addr __attribute__((unused))) {
 	return 0;
 }


### PR DESCRIPTION
 - Remove old GCC support code that worked around the lack of
   stdatomic.h support in GCC.
 - Conditional code in the NO_ATOMIC branch was broken (warnings, and
   no_atomic_mutex was being defined in multiple translation units).
   Fixed by moving the definition of no_atomic_mutex to its own file,
   added a new macro atomic_bool and replaced _Atomic(bool) and _Atomic
   bool across the codebase to leverage the atomic_bool macro (collision
   with standard defined atomic_bool is intentional, as in the NO_ATOMIC
   branch we know atomic_bool is not defined).
 - Reworked some of the conditionals to leverage standard defined macros
   as much as possible to detect features.

These changes are a little invasive, but I tested building the different conditionals by making different ones fail manually (`#ifdef 0`). All feasible branches of `atomic_support` now build with no warnings on GCC 10.2 and clang 11.0.0.

I am made a little uneasy by my defines of `atomic_flag` and `atomic_bool` as the defines aren't REALLY atomic and there's nothing stopping someone from accidentally using them as a `_Bool`. In C++ the solution is easy-ish-- define new classes and overload a whole bunch of operations. In C? The only alternative I can see in C is to make these new  types structs, and make it so these types can only be accessed via functions (which I think it's what we're doing anyway).

Also, a lingering question: What should be the standard for spacing? Tabs, spaces, or both (tabs for indentation, spaces for alignment)?